### PR TITLE
feat(iter3): Celery auto-deploy — GitHub projects with real-time logs

### DIFF
--- a/ITERATIONS.md
+++ b/ITERATIONS.md
@@ -10,66 +10,92 @@
 |------|------|------|
 | **Iter 1** | 项目骨架 + 后端核心 + 可运行环境 | ✅ 完成 |
 | **Iter 2** | 文章系统（上传 .md / 编辑器 / 渲染） | ✅ 完成 |
-| **Iter 3** | 项目展示 + Celery 自动部署 | 🔜 计划中 |
+| **Iter 3** | 项目展示 + Celery 自动部署 | ✅ 完成 |
 
 ---
 
 ## Iteration 1 — 项目骨架（已完成）
 
 ### 交付物
-- Docker Compose 一键启动（MySQL 8 / Redis 7 / FastAPI / Celery / Vue 3 Dev Server）
+- Docker Compose 一键启动（MySQL 8 / Redis 7 / FastAPI / Celery / Vue 3）
 - 后端全套 API（认证、Profile、文章 CRUD、项目 CRUD）
-- Alembic 迁移框架 + `init_db.py` 一键初始化
-- 前端完整路由体系 + 暗色主题 UI
-- 首页简历展示（工作经历时间轴、技能进度条、教育背景）
-- 文章列表 + 文章详情（Markdown 渲染，含语法高亮）
-- 项目列表（展示部署状态）
-- 管理后台骨架（个人资料编辑）
+- Alembic 迁移框架 + `init_db.py`
+- 前端完整路由 + 暗色主题 UI
+- 首页简历（工作经历时间轴、技能进度条、教育背景）
+- 文章列表 + 详情（Markdown 渲染 + 语法高亮）
+- 管理后台骨架
 
 ---
 
 ## Iteration 2 — 文章系统（已完成）
 
-### 交付物
-
-#### 后端新增
+### 新增接口
 | 接口 | 说明 |
 |------|------|
-| `POST /api/v1/articles/upload-md` | 上传 `.md` 文件，自动解析标题/摘要/标签，保存为草稿 |
-| `POST /api/v1/articles/{id}/cover` | 上传封面图（JPEG/PNG/WebP，≤5MB），存 `/uploads/covers/` |
-| `GET  /api/v1/articles/admin` | 管理员文章列表，支持 `q`（标题搜索）、`published` 筛选 |
-| `PUT  /api/v1/articles/{id}` | 更新文章，`is_published` 切换时自动写入 `published_at` |
-| `DELETE /api/v1/articles/{id}` | 删除文章同时清理封面图文件 |
+| `POST /api/v1/articles/upload-md` | 上传 `.md`，自动解析标题/摘要/标签，存为草稿 |
+| `POST /api/v1/articles/{id}/cover` | 上传封面图（JPEG/PNG/WebP ≤5MB） |
 
-#### 前端新增
-- **ArticleManager.vue** — 文章管理列表
-  - 搜索框 + 发布状态筛选
-  - 一键上传 `.md` 文件，自动跳转编辑器
-  - 发布/取消发布 Switch 实时切换
-  - 编辑 / 预览 / 删除操作
-- **ArticleEditor.vue** — 分栏 Markdown 编辑器
-  - 左栏：标题、摘要、标签、封面图上传、发布开关 + Markdown 编辑区
-  - 右栏：实时预览（marked + highlight.js）
-  - 工具栏：B / I / ` ` / 代码块 / H2 / H3 / 列表 / 引用 / 链接 / 图片
-  - 支持 Tab 缩进、导入 `.md` 文件覆盖
-
-### 用法
-```
-后台 → 文章管理 → 点击「上传.md」选择文件 → 自动解析标题/摘要 → 进入编辑器完善内容
-后台 → 文章管理 → 点击「新建文章」→ 在编辑器中手写 Markdown
-切换 is_published = true → 立即在前台文章列表可见
-```
+### 新增前端
+- **ArticleManager** — 搜索/筛选/上传 .md/发布 Switch/编辑/删除
+- **ArticleEditor** — 左右分栏编辑器（Markdown + 实时预览 + 工具栏 + 封面上传）
 
 ---
 
-## Iteration 3 — 项目自动部署（计划）
+## Iteration 3 — 项目自动部署（已完成）
 
-### 计划功能
-- [ ] 后台录入 GitHub URL + branch + 自定义命令
-- [ ] Celery Task `deploy_project`：git clone → 框架识别 → 安装依赖 → 构建 → 启动
-- [ ] 支持框架：Vue/React/Next.js/Node/FastAPI/Flask/Django/Static/Docker
-- [ ] 端口自动分配（8100~9000）
-- [ ] 部署日志轮询（`GET /projects/{id}/logs`）
-- [ ] 状态：pending → deploying → running / failed
-- [ ] 停止 / 重新部署操作
-- [ ] 前端卡片：运行状态绿点 + "访问" 按钮
+### 新增接口
+| 接口 | 说明 |
+|------|------|
+| `POST /api/v1/projects` | 创建项目，自动触发 Celery 部署 |
+| `POST /api/v1/projects/{id}/deploy` | 手动触发部署 |
+| `POST /api/v1/projects/{id}/redeploy` | 停止后重新部署 |
+| `POST /api/v1/projects/{id}/stop` | 停止运行中的项目 |
+| `GET  /api/v1/projects/{id}/logs` | 增量获取部署日志（offset 参数支持轮询） |
+| `POST /api/v1/projects/{id}/cover` | 上传项目封面图 |
+
+### Celery Task：`deploy_project`
+```
+git clone / pull
+    ↓
+框架自动识别
+    ↓
+安装依赖（npm install / pip install）
+    ↓
+构建（npm run build）
+    ↓
+端口分配（8100~9000 自动扫描）
+    ↓
+后台启动进程（独立进程组）
+    ↓
+更新 deploy_status = running，写入 deploy_url
+```
+
+### 支持框架
+| 框架 | 识别方式 | 启动方式 |
+|------|----------|----------|
+| Vue / React | `package.json` + build script | `serve -s dist -l {PORT}` |
+| Next.js | `next` in package.json | `PORT={PORT} npm start` |
+| Node.js | `package.json`（无 build） | `node index.js` |
+| FastAPI | `requirements.txt` + fastapi | `uvicorn main:app --port {PORT}` |
+| Flask | `requirements.txt` + flask | `flask run --port {PORT}` |
+| Django | `manage.py` | `python manage.py runserver 0.0.0.0:{PORT}` |
+| Static | `index.html` only | `serve -s . -l {PORT}` |
+| Docker | `Dockerfile` | `docker build + run -p {PORT}` |
+
+### 新增前端
+- **ProjectManager** — 卡片 grid，实时部署状态，操作按钮（部署/重部署/停止/删除）
+- **日志 Drawer** — 部署日志实时滚动，2s 增量轮询，自动停止
+- **ProjectsView（公开）** — 运行状态绿点 + "🚀 访问" 按钮，自动轮询部署中的项目
+
+### 快速启动
+```bash
+git clone https://github.com/teng00123/personal-landing.git
+cd personal-landing
+cp backend/.env.example backend/.env
+docker compose up -d
+docker compose exec backend python -m app.init_db
+
+# 主页:    http://localhost:5173
+# 后台:    http://localhost:5173/login   admin / Admin@123456
+# API 文档: http://localhost:8000/docs
+```

--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -1,12 +1,20 @@
 """
-项目 CRUD API
-迭代一：基础骨架（list / get / create / update / delete）
-迭代三：新增 Celery 自动部署 / 部署日志 / 重新部署
+项目 CRUD + 部署 API — Iteration 3
+新增：
+  POST /projects/{id}/deploy    触发 Celery 部署
+  POST /projects/{id}/stop      停止运行中的项目
+  POST /projects/{id}/redeploy  重新部署
+  GET  /projects/{id}/logs      获取部署日志（支持 offset 参数）
+  POST /projects/{id}/cover     上传封面图
+  PUT  /projects/{id}/stars     同步 GitHub stars/forks
 """
+import os
 import re
+import uuid
+from datetime import datetime, timezone
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
 from sqlalchemy import desc
 from sqlalchemy.orm import Session
 
@@ -17,6 +25,10 @@ from app.schemas.project import ProjectCreate, ProjectUpdate, ProjectOut, Projec
 from app.api.auth import require_admin
 
 router = APIRouter(prefix="/projects", tags=["projects"])
+
+UPLOAD_DIR = "./uploads/covers"
+ALLOWED_IMG = {"image/jpeg", "image/png", "image/webp", "image/gif"}
+MAX_IMG_SIZE = 5 * 1024 * 1024
 
 
 def _parse_repo(github_url: str) -> Optional[str]:
@@ -36,9 +48,7 @@ def list_projects(
     total = q.count()
     items = (
         q.order_by(Project.sort_order.asc(), desc(Project.created_at))
-        .offset((page - 1) * page_size)
-        .limit(page_size)
-        .all()
+        .offset((page - 1) * page_size).limit(page_size).all()
     )
     return ProjectPage(total=total, page=page, page_size=page_size, items=items)
 
@@ -57,21 +67,22 @@ def get_project_public(project_id: int, db: Session = Depends(get_db)):
 def admin_list(
     page: int = Query(1, ge=1),
     page_size: int = Query(20, ge=1, le=100),
+    q: Optional[str] = None,
     db: Session = Depends(get_db),
     _: User = Depends(require_admin),
 ):
-    total = db.query(Project).count()
+    query = db.query(Project)
+    if q:
+        query = query.filter(Project.name.ilike(f"%{q}%"))
+    total = query.count()
     items = (
-        db.query(Project)
-        .order_by(Project.sort_order.asc(), desc(Project.created_at))
-        .offset((page - 1) * page_size)
-        .limit(page_size)
-        .all()
+        query.order_by(Project.sort_order.asc(), desc(Project.created_at))
+        .offset((page - 1) * page_size).limit(page_size).all()
     )
     return ProjectPage(total=total, page=page, page_size=page_size, items=items)
 
 
-@router.post("", response_model=ProjectOut, status_code=201, summary="新建项目（触发部署在迭代三实现）")
+@router.post("", response_model=ProjectOut, status_code=201, summary="新建项目（自动触发部署）")
 def create_project(
     body: ProjectCreate,
     db: Session = Depends(get_db),
@@ -83,11 +94,22 @@ def create_project(
         github_repo=github_repo,
         owner_id=admin.id,
         deploy_status="pending",
+        deploy_log="[待部署] 项目已创建，点击「部署」开始自动部署。\n",
     )
     db.add(project)
     db.commit()
     db.refresh(project)
-    # 迭代三：在这里调用 deploy_project.delay(project.id)
+
+    # 自动触发部署
+    try:
+        from app.tasks.deploy import deploy_project
+        deploy_project.delay(project.id)
+        project.deploy_status = "deploying"
+        db.commit()
+        db.refresh(project)
+    except Exception:
+        pass  # Celery 不可用时不影响创建
+
     return project
 
 
@@ -129,5 +151,129 @@ def delete_project(
     p = db.get(Project, project_id)
     if not p:
         raise HTTPException(404, "项目不存在")
+    # 停止进程
+    try:
+        from app.tasks.deploy import stop_project
+        stop_project.delay(project_id)
+    except Exception:
+        pass
     db.delete(p)
     db.commit()
+
+
+# ── 部署操作 ───────────────────────────────────────────────
+
+@router.post("/{project_id}/deploy", response_model=ProjectOut, summary="触发部署")
+def trigger_deploy(
+    project_id: int,
+    db: Session = Depends(get_db),
+    _: User = Depends(require_admin),
+):
+    p = db.get(Project, project_id)
+    if not p:
+        raise HTTPException(404, "项目不存在")
+    if p.deploy_status == "deploying":
+        raise HTTPException(409, "项目正在部署中")
+
+    from app.tasks.deploy import deploy_project
+    p.deploy_status = "deploying"
+    p.deploy_log = "[deploy] 手动触发部署...\n"
+    db.commit()
+    db.refresh(p)
+    deploy_project.delay(project_id)
+    return p
+
+
+@router.post("/{project_id}/redeploy", response_model=ProjectOut, summary="重新部署")
+def redeploy(
+    project_id: int,
+    db: Session = Depends(get_db),
+    _: User = Depends(require_admin),
+):
+    p = db.get(Project, project_id)
+    if not p:
+        raise HTTPException(404, "项目不存在")
+
+    from app.tasks.deploy import stop_project, deploy_project
+    stop_project.delay(project_id)
+
+    p.deploy_status = "deploying"
+    p.deploy_log = "[redeploy] 重新部署中...\n"
+    db.commit()
+    db.refresh(p)
+    deploy_project.apply_async((project_id,), countdown=3)
+    return p
+
+
+@router.post("/{project_id}/stop", response_model=ProjectOut, summary="停止项目")
+def stop(
+    project_id: int,
+    db: Session = Depends(get_db),
+    _: User = Depends(require_admin),
+):
+    p = db.get(Project, project_id)
+    if not p:
+        raise HTTPException(404, "项目不存在")
+
+    from app.tasks.deploy import stop_project
+    stop_project.delay(project_id)
+
+    p.deploy_status = "stopped"
+    db.commit()
+    db.refresh(p)
+    return p
+
+
+@router.get("/{project_id}/logs", summary="获取部署日志")
+def get_logs(
+    project_id: int,
+    offset: int = Query(0, ge=0, description="从第几个字符开始返回（用于增量轮询）"),
+    db: Session = Depends(get_db),
+    _: User = Depends(require_admin),
+):
+    p = db.get(Project, project_id)
+    if not p:
+        raise HTTPException(404, "项目不存在")
+    log = p.deploy_log or ""
+    return {
+        "project_id": project_id,
+        "status": p.deploy_status,
+        "log": log[offset:],
+        "total_length": len(log),
+        "deploy_url": p.deploy_url,
+    }
+
+
+# ── 封面图上传 ─────────────────────────────────────────────
+
+@router.post("/{project_id}/cover", response_model=ProjectOut, summary="上传封面图")
+async def upload_cover(
+    project_id: int,
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+    _: User = Depends(require_admin),
+):
+    p = db.get(Project, project_id)
+    if not p:
+        raise HTTPException(404, "项目不存在")
+    if file.content_type not in ALLOWED_IMG:
+        raise HTTPException(400, f"不支持的图片类型: {file.content_type}")
+    raw = await file.read()
+    if len(raw) > MAX_IMG_SIZE:
+        raise HTTPException(413, "图片不能超过 5MB")
+
+    os.makedirs(UPLOAD_DIR, exist_ok=True)
+    ext = file.filename.rsplit(".", 1)[-1] if "." in file.filename else "jpg"
+    filename = f"{uuid.uuid4().hex}.{ext}"
+    with open(os.path.join(UPLOAD_DIR, filename), "wb") as f:
+        f.write(raw)
+
+    if p.cover_image and p.cover_image.startswith("/uploads/"):
+        old = "." + p.cover_image
+        if os.path.exists(old):
+            os.remove(old)
+
+    p.cover_image = f"/uploads/covers/{filename}"
+    db.commit()
+    db.refresh(p)
+    return p

--- a/backend/app/tasks/deploy.py
+++ b/backend/app/tasks/deploy.py
@@ -1,16 +1,313 @@
 """
-deploy.py — 占位文件，迭代三实现 Celery 自动部署任务
+deploy.py — Iteration 3
+Celery 自动部署任务：git clone / pull → 框架识别 → 安装依赖 → 构建 → 启动进程
 """
+import os
+import re
+import signal
+import socket
+import subprocess
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+
+from celery import Task
+from sqlalchemy.orm import Session
+
 from app.tasks.celery_app import celery_app
+from app.db.session import SessionLocal
+from app.models.project import Project
+from app.core.config import settings
 
 
-@celery_app.task(name="deploy_project")
-def deploy_project(project_id: int):
-    """迭代三实现：git clone → 检测框架 → 安装依赖 → 启动进程"""
-    raise NotImplementedError("deploy_project will be implemented in iteration 3")
+# ── 工具函数 ───────────────────────────────────────────────
+
+def _find_free_port(start: int = None, end: int = 9000) -> int:
+    start = start or settings.DEPLOY_BASE_PORT
+    for port in range(start, end):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            try:
+                s.bind(("0.0.0.0", port))
+                return port
+            except OSError:
+                continue
+    raise RuntimeError("没有可用端口")
+
+
+def _detect_framework(proj_dir: Path) -> str:
+    """自动识别项目框架"""
+    # Docker 优先
+    if (proj_dir / "Dockerfile").exists():
+        return "docker"
+
+    pkg = proj_dir / "package.json"
+    req = proj_dir / "requirements.txt"
+
+    if pkg.exists():
+        content = pkg.read_text(errors="replace")
+        if "next" in content:
+            return "nextjs"
+        if '"build"' in content:
+            return "vue-react"   # Vue / React / 其他有 build 脚本的 SPA
+        return "nodejs"
+
+    if req.exists():
+        content = req.read_text(errors="replace").lower()
+        if "fastapi" in content or "uvicorn" in content:
+            return "fastapi"
+        if "flask" in content:
+            return "flask"
+        if "django" in content:
+            return "django"
+
+    # manage.py → Django
+    if (proj_dir / "manage.py").exists():
+        return "django"
+    # app.py / main.py → 猜 Flask
+    if (proj_dir / "app.py").exists() or (proj_dir / "main.py").exists():
+        return "flask"
+
+    # 纯静态
+    if (proj_dir / "index.html").exists():
+        return "static"
+
+    return "unknown"
+
+
+def _run(cmd: str, cwd: Path, log_cb, timeout: int = 300) -> bool:
+    """执行 shell 命令，把输出回调给 log_cb，返回是否成功"""
+    log_cb(f"$ {cmd}\n")
+    proc = subprocess.Popen(
+        cmd, shell=True, cwd=str(cwd),
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        text=True, bufsize=1,
+    )
+    try:
+        for line in proc.stdout:
+            log_cb(line)
+        proc.wait(timeout=timeout)
+        return proc.returncode == 0
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        log_cb(f"\n[TIMEOUT] 命令执行超过 {timeout}s，已终止\n")
+        return False
+
+
+def _write_pid(proj_dir: Path, pid: int):
+    (proj_dir / ".deploy.pid").write_text(str(pid))
+
+
+def _read_pid(proj_dir: Path) -> int | None:
+    f = proj_dir / ".deploy.pid"
+    if f.exists():
+        try:
+            return int(f.read_text().strip())
+        except ValueError:
+            pass
+    return None
+
+
+def _kill_process(proj_dir: Path):
+    pid = _read_pid(proj_dir)
+    if pid:
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+
+
+# ── 数据库更新辅助 ─────────────────────────────────────────
+
+def _update_project(project_id: int, **kwargs):
+    db: Session = SessionLocal()
+    try:
+        p = db.get(Project, project_id)
+        if p:
+            for k, v in kwargs.items():
+                setattr(p, k, v)
+            db.commit()
+    finally:
+        db.close()
+
+
+def _append_log(project_id: int, text: str):
+    db: Session = SessionLocal()
+    try:
+        p = db.get(Project, project_id)
+        if p:
+            p.deploy_log = (p.deploy_log or "") + text
+            db.commit()
+    finally:
+        db.close()
+
+
+# ── Celery Tasks ───────────────────────────────────────────
+
+@celery_app.task(name="deploy_project", bind=True)
+def deploy_project(self: Task, project_id: int):
+    """
+    全流程部署：
+    1. git clone / pull
+    2. 框架识别
+    3. 安装依赖
+    4. 构建
+    5. 启动进程（后台）
+    """
+    # 清空旧日志，状态→deploying
+    _update_project(project_id,
+                    deploy_status="deploying",
+                    deploy_log="[deploy] 开始部署...\n")
+
+    def log(text: str):
+        _append_log(project_id, text)
+
+    # 拉取项目信息
+    db: Session = SessionLocal()
+    try:
+        p = db.get(Project, project_id)
+        if not p:
+            return
+        github_url   = p.github_url
+        branch       = p.deploy_branch or "main"
+        custom_cmd   = p.deploy_command
+        project_name = re.sub(r"[^\w-]", "_", p.name)
+    finally:
+        db.close()
+
+    base_dir  = Path(settings.DEPLOY_BASE_DIR)
+    proj_dir  = base_dir / f"proj_{project_id}_{project_name}"
+    base_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        # ── Step 1: clone / pull ──────────────────────────
+        if proj_dir.exists():
+            log(f"[git] 目录已存在，执行 git pull (branch: {branch})\n")
+            _kill_process(proj_dir)
+            ok = _run(f"git fetch origin && git checkout {branch} && git reset --hard origin/{branch}",
+                      proj_dir, log)
+        else:
+            log(f"[git] clone {github_url} (branch: {branch})\n")
+            ok = _run(f"git clone --depth=1 --branch {branch} {github_url} {proj_dir}", base_dir, log)
+
+        if not ok:
+            raise RuntimeError("git clone/pull 失败")
+
+        # ── Step 2: 框架识别 ──────────────────────────────
+        fw = _detect_framework(proj_dir)
+        log(f"[detect] 框架识别: {fw}\n")
+        _update_project(project_id, framework=fw)
+
+        # ── Step 3 & 4: 安装 + 构建 ──────────────────────
+        if fw in ("vue-react",):
+            if not _run("npm install --prefer-offline", proj_dir, log):
+                raise RuntimeError("npm install 失败")
+            if not _run("npm run build", proj_dir, log):
+                raise RuntimeError("npm run build 失败")
+
+        elif fw == "nextjs":
+            if not _run("npm install --prefer-offline", proj_dir, log):
+                raise RuntimeError("npm install 失败")
+            if not _run("npm run build", proj_dir, log):
+                raise RuntimeError("npm run build 失败")
+
+        elif fw == "nodejs":
+            if not _run("npm install --prefer-offline", proj_dir, log):
+                raise RuntimeError("npm install 失败")
+
+        elif fw in ("fastapi", "flask", "django"):
+            venv = proj_dir / ".venv"
+            if not venv.exists():
+                if not _run("python3 -m venv .venv", proj_dir, log):
+                    raise RuntimeError("创建 venv 失败")
+            pip = venv / "bin" / "pip"
+            req_file = proj_dir / "requirements.txt"
+            if req_file.exists():
+                if not _run(f"{pip} install -r requirements.txt -q", proj_dir, log):
+                    raise RuntimeError("pip install 失败")
+
+        elif fw == "docker":
+            tag = f"personal_landing_{project_id}"
+            if not _run(f"docker build -t {tag} .", proj_dir, log):
+                raise RuntimeError("docker build 失败")
+
+        # ── Step 5: 分配端口 & 启动 ───────────────────────
+        port = _find_free_port()
+        log(f"[port] 分配端口: {port}\n")
+
+        if custom_cmd:
+            start_cmd = custom_cmd.replace("{PORT}", str(port))
+        elif fw == "vue-react":
+            dist = "dist"
+            for candidate in ("dist", "build", "out", ".output/public"):
+                if (proj_dir / candidate).exists():
+                    dist = candidate
+                    break
+            start_cmd = f"serve -s {dist} -l {port}"
+        elif fw == "nextjs":
+            start_cmd = f"PORT={port} npm start"
+        elif fw == "nodejs":
+            entry = "index.js" if (proj_dir / "index.js").exists() else "app.js"
+            start_cmd = f"PORT={port} node {entry}"
+        elif fw == "fastapi":
+            venv_python = str(proj_dir / ".venv" / "bin" / "python")
+            main_file = "main:app" if (proj_dir / "main.py").exists() else "app.main:app"
+            start_cmd = f"{venv_python} -m uvicorn {main_file} --host 0.0.0.0 --port {port}"
+        elif fw == "flask":
+            venv_python = str(proj_dir / ".venv" / "bin" / "python")
+            app_file = "app.py" if (proj_dir / "app.py").exists() else "main.py"
+            start_cmd = f"FLASK_APP={app_file} FLASK_ENV=production {venv_python} -m flask run --host 0.0.0.0 --port {port}"
+        elif fw == "django":
+            venv_python = str(proj_dir / ".venv" / "bin" / "python")
+            start_cmd = f"{venv_python} manage.py runserver 0.0.0.0:{port}"
+        elif fw == "static":
+            start_cmd = f"serve -s . -l {port}"
+        elif fw == "docker":
+            tag = f"personal_landing_{project_id}"
+            start_cmd = f"docker run -d -p {port}:{port} --name {tag} {tag}"
+        else:
+            raise RuntimeError(f"无法识别框架 '{fw}'，请在项目中填写自定义启动命令")
+
+        log(f"[start] {start_cmd}\n")
+
+        # 后台启动进程（不阻塞 Celery worker）
+        proc = subprocess.Popen(
+            start_cmd, shell=True, cwd=str(proj_dir),
+            stdout=open(proj_dir / "stdout.log", "w"),
+            stderr=open(proj_dir / "stderr.log", "w"),
+            preexec_fn=os.setsid,   # 独立进程组，防止 worker 退出时被 kill
+        )
+        _write_pid(proj_dir, proc.pid)
+
+        deploy_url = f"{settings.DEPLOY_BASE_URL}:{port}"
+        log(f"[done] 部署成功！访问: {deploy_url}\n")
+
+        _update_project(project_id,
+                        deploy_status="running",
+                        deploy_port=port,
+                        deploy_url=deploy_url,
+                        last_deployed_at=datetime.now(timezone.utc))
+
+    except Exception as exc:
+        log(f"\n[ERROR] {exc}\n")
+        _update_project(project_id, deploy_status="failed")
+        raise
 
 
 @celery_app.task(name="stop_project")
 def stop_project(project_id: int):
-    """迭代三实现"""
-    raise NotImplementedError("stop_project will be implemented in iteration 3")
+    """停止已部署的项目进程"""
+    db: Session = SessionLocal()
+    try:
+        p = db.get(Project, project_id)
+        if not p:
+            return
+        project_name = re.sub(r"[^\w-]", "_", p.name)
+    finally:
+        db.close()
+
+    proj_dir = Path(settings.DEPLOY_BASE_DIR) / f"proj_{project_id}_{project_name}"
+    _kill_process(proj_dir)
+    _update_project(project_id,
+                    deploy_status="stopped",
+                    deploy_port=None,
+                    deploy_url=None)

--- a/frontend/src/api/endpoints.js
+++ b/frontend/src/api/endpoints.js
@@ -15,30 +15,40 @@ export const profileApi = {
 // ── Articles ─────────────────────────────────────────────
 export const articlesApi = {
   // 公开
-  list:       (p)       => http.get('/articles',              { params: p }),
-  getBySlug:  (slug)    => http.get(`/articles/slug/${slug}`),
+  list:        (p)       => http.get('/articles',              { params: p }),
+  getBySlug:   (slug)    => http.get(`/articles/slug/${slug}`),
   // 管理员
-  adminList:  (p)       => http.get('/articles/admin',        { params: p }),
-  getById:    (id)      => http.get(`/articles/${id}`),
-  create:     (d)       => http.post('/articles', d),
-  update:     (id, d)   => http.put(`/articles/${id}`, d),
-  remove:     (id)      => http.delete(`/articles/${id}`),
-  // 迭代二新增
-  uploadMd:   (fd)      => http.post('/articles/upload-md', fd, {
+  adminList:   (p)       => http.get('/articles/admin',        { params: p }),
+  getById:     (id)      => http.get(`/articles/${id}`),
+  create:      (d)       => http.post('/articles', d),
+  update:      (id, d)   => http.put(`/articles/${id}`, d),
+  remove:      (id)      => http.delete(`/articles/${id}`),
+  // 迭代二
+  uploadMd:    (fd)      => http.post('/articles/upload-md', fd, {
     headers: { 'Content-Type': 'multipart/form-data' },
   }),
-  uploadCover: (id, fd) => http.post(`/articles/${id}/cover`, fd, {
+  uploadCover: (id, fd)  => http.post(`/articles/${id}/cover`, fd, {
     headers: { 'Content-Type': 'multipart/form-data' },
   }),
 }
 
 // ── Projects ─────────────────────────────────────────────
 export const projectsApi = {
-  list:      (p)      => http.get('/projects',          { params: p }),
-  getPublic: (id)     => http.get(`/projects/public/${id}`),
-  adminList: (p)      => http.get('/projects/admin',    { params: p }),
-  getById:   (id)     => http.get(`/projects/${id}`),
-  create:    (d)      => http.post('/projects', d),
-  update:    (id, d)  => http.put(`/projects/${id}`, d),
-  remove:    (id)     => http.delete(`/projects/${id}`),
+  // 公开
+  list:        (p)      => http.get('/projects',          { params: p }),
+  getPublic:   (id)     => http.get(`/projects/public/${id}`),
+  // 管理员 CRUD
+  adminList:   (p)      => http.get('/projects/admin',    { params: p }),
+  getById:     (id)     => http.get(`/projects/${id}`),
+  create:      (d)      => http.post('/projects', d),
+  update:      (id, d)  => http.put(`/projects/${id}`, d),
+  remove:      (id)     => http.delete(`/projects/${id}`),
+  uploadCover: (id, fd) => http.post(`/projects/${id}/cover`, fd, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  }),
+  // 迭代三：部署操作
+  deploy:      (id)     => http.post(`/projects/${id}/deploy`),
+  redeploy:    (id)     => http.post(`/projects/${id}/redeploy`),
+  stop:        (id)     => http.post(`/projects/${id}/stop`),
+  logs:        (id, offset = 0) => http.get(`/projects/${id}/logs`, { params: { offset } }),
 }

--- a/frontend/src/views/admin/ProjectManager.vue
+++ b/frontend/src/views/admin/ProjectManager.vue
@@ -1,20 +1,362 @@
 <template>
   <div>
-    <h2 class="page-h2">🚀 项目管理</h2>
-    <el-result
-      icon="info"
-      title="迭代三实现"
-      sub-title="GitHub 项目导入、Celery 自动部署、实时日志、运行状态监控将在迭代三完成。"
-    >
-      <template #extra>
-        <el-tag type="warning">Coming in Iteration 3</el-tag>
+    <div class="page-head">
+      <h2 class="page-h2">🚀 项目管理</h2>
+      <div class="head-actions">
+        <el-input v-model="searchQ" placeholder="搜索项目名..." clearable style="width:200px"
+          @keyup.enter="loadList" @clear="loadList">
+          <template #prefix><el-icon><Search /></el-icon></template>
+        </el-input>
+        <el-button type="primary" :icon="Plus" @click="openForm(null)">添加项目</el-button>
+      </div>
+    </div>
+
+    <!-- 项目卡片 grid -->
+    <div v-loading="loading" class="proj-grid">
+      <div v-for="p in projects" :key="p.id" class="proj-card card">
+
+        <!-- 封面 -->
+        <div class="proj-cover-wrap">
+          <img v-if="p.cover_image" :src="p.cover_image" class="proj-cover" />
+          <div v-else class="proj-cover-ph">{{ p.name[0]?.toUpperCase() }}</div>
+          <div class="proj-status-badge" :class="p.deploy_status">
+            <span class="dot" :class="p.deploy_status"></span>
+            {{ statusLabel(p.deploy_status) }}
+          </div>
+        </div>
+
+        <!-- 内容 -->
+        <div class="proj-body">
+          <h3 class="proj-name">{{ p.name }}</h3>
+          <p class="proj-desc text-muted">{{ p.description || '暂无描述' }}</p>
+
+          <div class="tag-row">
+            <el-tag v-for="t in parseTags(p.tech_stack || p.tags)" :key="t" size="small" type="info">{{ t }}</el-tag>
+          </div>
+
+          <div class="proj-meta">
+            <span v-if="p.deploy_url">
+              🔗 <a :href="p.deploy_url" target="_blank" class="deploy-link">{{ p.deploy_url }}</a>
+            </span>
+            <span v-if="p.framework" class="fw-badge">{{ p.framework }}</span>
+          </div>
+        </div>
+
+        <!-- 操作 -->
+        <div class="proj-actions">
+          <el-button size="small" type="success" :icon="VideoPlay"
+            :disabled="p.deploy_status === 'deploying'"
+            @click="doDeploy(p)">
+            {{ p.deploy_status === 'deploying' ? '部署中...' : '部署' }}
+          </el-button>
+          <el-button size="small" type="warning" :icon="RefreshRight"
+            :disabled="p.deploy_status === 'deploying'"
+            @click="doRedeploy(p)">重部署</el-button>
+          <el-button size="small" type="info" :icon="VideoPause"
+            :disabled="p.deploy_status !== 'running'"
+            @click="doStop(p)">停止</el-button>
+          <el-button size="small" :icon="DocumentCopy" @click="openLogs(p)">日志</el-button>
+          <el-button size="small" :icon="Edit" @click="openForm(p)">编辑</el-button>
+          <el-button size="small" type="danger" :icon="Delete" @click="removeProject(p)">删除</el-button>
+        </div>
+
+      </div>
+    </div>
+
+    <el-empty v-if="!loading && !projects.length" description="暂无项目，点击「添加项目」开始" style="padding:80px 0" />
+
+    <!-- 分页 -->
+    <div class="pager" v-if="total > pageSize">
+      <el-pagination v-model:current-page="page" :page-size="pageSize" :total="total"
+        background layout="prev,pager,next,total" @current-change="loadList" />
+    </div>
+
+    <!-- ── 新建/编辑 Dialog ─────────────────────────────── -->
+    <el-dialog v-model="formVisible" :title="formId ? '编辑项目' : '添加项目'"
+      width="560px" :close-on-click-modal="false">
+      <el-form :model="form" label-position="top" style="padding:0 4px">
+        <el-form-item label="项目名称 *">
+          <el-input v-model="form.name" placeholder="My Awesome Project" />
+        </el-form-item>
+        <el-form-item label="GitHub URL *">
+          <el-input v-model="form.github_url" placeholder="https://github.com/user/repo" />
+        </el-form-item>
+        <el-form-item label="描述">
+          <el-input v-model="form.description" type="textarea" :rows="2" />
+        </el-form-item>
+        <el-row :gutter="12">
+          <el-col :span="12">
+            <el-form-item label="部署分支">
+              <el-input v-model="form.deploy_branch" placeholder="main" />
+            </el-form-item>
+          </el-col>
+          <el-col :span="12">
+            <el-form-item label="技术标签（逗号分隔）">
+              <el-input v-model="form.tech_stack" placeholder="Vue, FastAPI, Docker" />
+            </el-form-item>
+          </el-col>
+        </el-row>
+        <el-form-item label="自定义启动命令（可选，留空则自动识别）">
+          <el-input v-model="form.deploy_command" placeholder="node server.js --port {PORT}" />
+        </el-form-item>
+        <el-form-item label="显示在主页">
+          <el-switch v-model="form.is_published" active-text="是" inactive-text="否" />
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <el-button @click="formVisible = false">取消</el-button>
+        <el-button type="primary" :loading="saving" @click="saveProject">
+          {{ formId ? '保存' : '创建并部署' }}
+        </el-button>
       </template>
-    </el-result>
+    </el-dialog>
+
+    <!-- ── 日志 Drawer ──────────────────────────────────── -->
+    <el-drawer v-model="logsVisible" :title="`部署日志 — ${logsProject?.name}`"
+      size="55%" direction="rtl" @close="stopLogPolling">
+      <div class="log-toolbar">
+        <el-tag :type="logStatusType" size="small">{{ statusLabel(logsProject?.deploy_status) }}</el-tag>
+        <span v-if="logsProject?.deploy_url" style="margin-left:12px;font-size:13px">
+          🔗 <a :href="logsProject.deploy_url" target="_blank" class="deploy-link">{{ logsProject.deploy_url }}</a>
+        </span>
+        <el-button size="small" style="margin-left:auto" :icon="RefreshRight" @click="fetchLogs(true)">刷新</el-button>
+      </div>
+      <div class="log-body" ref="logBodyRef">
+        <pre class="log-pre">{{ logContent || '（暂无日志）' }}</pre>
+      </div>
+    </el-drawer>
+
   </div>
 </template>
 
-<script setup></script>
+<script setup>
+import { ref, computed, onUnmounted, nextTick } from 'vue'
+import { ElMessage, ElMessageBox } from 'element-plus'
+import {
+  Search, Plus, VideoPlay, VideoPause, RefreshRight,
+  DocumentCopy, Edit, Delete,
+} from '@element-plus/icons-vue'
+import { projectsApi } from '@/api/endpoints.js'
+
+// ── List ──────────────────────────────────────────────────
+const projects = ref([])
+const total    = ref(0)
+const page     = ref(1)
+const pageSize = 12
+const loading  = ref(false)
+const searchQ  = ref('')
+
+const parseTags   = (t) => (t || '').split(',').map(s => s.trim()).filter(Boolean)
+const statusLabel = (s) => ({ pending:'待部署', deploying:'部署中', running:'运行中', failed:'失败', stopped:'已停止' }[s] ?? s)
+
+async function loadList() {
+  loading.value = true
+  try {
+    const res = await projectsApi.adminList({ page: page.value, page_size: pageSize, q: searchQ.value || undefined })
+    projects.value = res.items ?? []
+    total.value    = res.total
+  } finally { loading.value = false }
+}
+
+// ── Form ──────────────────────────────────────────────────
+const formVisible = ref(false)
+const formId      = ref(null)
+const saving      = ref(false)
+const form        = ref({ name:'', github_url:'', description:'', deploy_branch:'main', tech_stack:'', deploy_command:'', is_published:true })
+
+function openForm(p) {
+  formId.value = p?.id ?? null
+  if (p) {
+    form.value = {
+      name: p.name, github_url: p.github_url, description: p.description ?? '',
+      deploy_branch: p.deploy_branch ?? 'main', tech_stack: p.tech_stack ?? '',
+      deploy_command: p.deploy_command ?? '', is_published: p.is_published,
+    }
+  } else {
+    form.value = { name:'', github_url:'', description:'', deploy_branch:'main', tech_stack:'', deploy_command:'', is_published:true }
+  }
+  formVisible.value = true
+}
+
+async function saveProject() {
+  if (!form.value.name.trim()) { ElMessage.warning('请填写项目名称'); return }
+  if (!form.value.github_url.trim()) { ElMessage.warning('请填写 GitHub URL'); return }
+  saving.value = true
+  try {
+    if (formId.value) {
+      await projectsApi.update(formId.value, form.value)
+      ElMessage.success('已保存')
+    } else {
+      await projectsApi.create(form.value)
+      ElMessage.success('项目已创建，自动开始部署')
+    }
+    formVisible.value = false
+    loadList()
+  } catch (e) {
+    ElMessage.error(e?.detail || '操作失败')
+  } finally { saving.value = false }
+}
+
+// ── Deploy actions ────────────────────────────────────────
+async function doDeploy(p) {
+  try {
+    await projectsApi.deploy(p.id)
+    ElMessage.success('部署已触发')
+    startAutoRefresh()
+    loadList()
+  } catch (e) { ElMessage.error(e?.detail || '触发失败') }
+}
+
+async function doRedeploy(p) {
+  try {
+    await ElMessageBox.confirm(`重新部署「${p.name}」？将先停止再重新 clone & 构建。`, '确认重部署', {
+      type: 'warning', confirmButtonText: '重部署', cancelButtonText: '取消',
+    })
+    await projectsApi.redeploy(p.id)
+    ElMessage.success('重部署已触发')
+    startAutoRefresh()
+    loadList()
+  } catch {}
+}
+
+async function doStop(p) {
+  try {
+    await projectsApi.stop(p.id)
+    ElMessage.success('已停止')
+    loadList()
+  } catch (e) { ElMessage.error(e?.detail || '停止失败') }
+}
+
+async function removeProject(p) {
+  try {
+    await ElMessageBox.confirm(`确认删除「${p.name}」？进程将被停止。`, '删除确认', {
+      type: 'warning', confirmButtonText: '删除', cancelButtonText: '取消',
+    })
+    await projectsApi.remove(p.id)
+    ElMessage.success('已删除')
+    loadList()
+  } catch {}
+}
+
+// ── 自动刷新（部署中时轮询） ──────────────────────────────
+let refreshTimer = null
+function startAutoRefresh() {
+  if (refreshTimer) return
+  refreshTimer = setInterval(async () => {
+    await loadList()
+    const deploying = projects.value.some(p => p.deploy_status === 'deploying')
+    if (!deploying) stopAutoRefresh()
+  }, 3000)
+}
+function stopAutoRefresh() {
+  clearInterval(refreshTimer)
+  refreshTimer = null
+}
+
+// ── Logs ──────────────────────────────────────────────────
+const logsVisible  = ref(false)
+const logsProject  = ref(null)
+const logContent   = ref('')
+const logBodyRef   = ref(null)
+let logOffset      = 0
+let logTimer       = null
+
+const logStatusType = computed(() => ({
+  running:'success', deploying:'warning', failed:'danger', stopped:'info', pending:'info',
+}[logsProject.value?.deploy_status] ?? 'info'))
+
+async function openLogs(p) {
+  logsProject.value = p
+  logContent.value  = ''
+  logOffset         = 0
+  logsVisible.value = true
+  await fetchLogs(true)
+  // 轮询（部署中时每 2s 刷新）
+  logTimer = setInterval(() => {
+    if (['deploying'].includes(logsProject.value?.deploy_status)) fetchLogs(false)
+    else stopLogPolling()
+  }, 2000)
+}
+
+async function fetchLogs(reset = false) {
+  if (!logsProject.value) return
+  if (reset) { logContent.value = ''; logOffset = 0 }
+  try {
+    const res = await projectsApi.logs(logsProject.value.id, logOffset)
+    if (res.log) {
+      logContent.value += res.log
+      logOffset = res.total_length
+    }
+    // 同步状态
+    logsProject.value = { ...logsProject.value, deploy_status: res.status, deploy_url: res.deploy_url }
+    // 滚动到底部
+    await nextTick()
+    if (logBodyRef.value) logBodyRef.value.scrollTop = logBodyRef.value.scrollHeight
+  } catch {}
+}
+
+function stopLogPolling() {
+  clearInterval(logTimer)
+  logTimer = null
+}
+
+onUnmounted(() => {
+  stopAutoRefresh()
+  stopLogPolling()
+})
+
+// 初始加载
+loadList()
+</script>
 
 <style scoped>
-.page-h2 { font-size: 1.375rem; font-weight: 700; color: #f1f5f9; margin-bottom: 24px; }
+.page-head    { display:flex; justify-content:space-between; align-items:center; margin-bottom:20px; flex-wrap:wrap; gap:12px; }
+.page-h2      { font-size:1.375rem; font-weight:700; color:#f1f5f9; }
+.head-actions { display:flex; gap:10px; align-items:center; }
+
+/* 卡片 grid */
+.proj-grid { display:grid; grid-template-columns:repeat(auto-fill,minmax(320px,1fr)); gap:20px; }
+.proj-card { display:flex; flex-direction:column; gap:12px; padding:0; overflow:hidden; }
+
+/* 封面 */
+.proj-cover-wrap { position:relative; }
+.proj-cover    { width:100%; height:160px; object-fit:cover; }
+.proj-cover-ph {
+  width:100%; height:120px; background:linear-gradient(135deg,#1e293b,#334155);
+  display:flex; align-items:center; justify-content:center;
+  font-size:3rem; font-weight:800; color:rgba(59,130,246,.3);
+}
+.proj-status-badge {
+  position:absolute; top:10px; right:10px;
+  display:flex; align-items:center; gap:5px;
+  padding:3px 10px; border-radius:20px; font-size:.75rem; font-weight:600;
+  background:rgba(15,23,42,.75); backdrop-filter:blur(4px);
+  color:#94a3b8;
+}
+.proj-status-badge.running   { color:#10b981; }
+.proj-status-badge.deploying { color:#f59e0b; }
+.proj-status-badge.failed    { color:#ef4444; }
+.dot { width:7px; height:7px; border-radius:50%; background:currentColor; }
+.dot.running   { animation: pulse 2s infinite; }
+.dot.deploying { animation: pulse 1s infinite; }
+
+/* 内容 */
+.proj-body  { padding:0 16px; display:flex; flex-direction:column; gap:8px; flex:1; }
+.proj-name  { font-size:.9375rem; font-weight:700; color:#f1f5f9; }
+.proj-desc  { font-size:.8125rem; display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden; }
+.tag-row    { display:flex; gap:5px; flex-wrap:wrap; }
+.proj-meta  { display:flex; align-items:center; gap:8px; font-size:.8125rem; color:#64748b; flex-wrap:wrap; }
+.deploy-link { color:#60a5fa; word-break:break-all; }
+.deploy-link:hover { text-decoration:underline; }
+.fw-badge { padding:2px 8px; border-radius:4px; background:rgba(139,92,246,.15); color:#a78bfa; font-size:.75rem; }
+
+/* 操作 */
+.proj-actions { padding:12px 16px; border-top:1px solid #1e293b; display:flex; flex-wrap:wrap; gap:6px; }
+
+.pager { display:flex; justify-content:flex-end; margin-top:20px; }
+
+/* 日志 */
+.log-toolbar { display:flex; align-items:center; padding:0 0 12px; border-bottom:1px solid #1e293b; flex-wrap:wrap; gap:8px; }
+.log-body    { margin-top:12px; background:#0d1117; border-radius:8px; height:calc(100vh - 180px); overflow-y:auto; }
+.log-pre     { padding:16px; font-family:'JetBrains Mono','Fira Code',monospace; font-size:12.5px; line-height:1.7; color:#e2e8f0; white-space:pre-wrap; word-break:break-all; margin:0; }
 </style>

--- a/frontend/src/views/public/ProjectsView.vue
+++ b/frontend/src/views/public/ProjectsView.vue
@@ -3,23 +3,27 @@
     <div class="container">
       <h1 class="section-title fade-in-up">项目展示</h1>
       <p class="text-muted fade-in-up" style="margin-bottom:48px;font-size:1.05rem">
-        GitHub 项目 · 自动部署 · 实时访问
-        <el-tag type="info" size="small" style="margin-left:8px">自动部署将在迭代三实现</el-tag>
+        GitHub 开源项目 · Celery 自动部署 · 实时访问
       </p>
 
       <div v-loading="loading" class="proj-grid">
-        <div v-for="p in projects" :key="p.id" class="card proj-card fade-in-up">
-
-          <!-- 状态 -->
+        <div
+          v-for="p in projects"
+          :key="p.id"
+          class="card proj-card fade-in-up"
+          :style="{ animationDelay: `${projects.indexOf(p) * 0.06}s` }"
+        >
+          <!-- 状态徽章 -->
           <div class="proj-status">
             <span class="dot" :class="p.deploy_status"></span>
             <span class="status-txt" :class="p.deploy_status">{{ statusLabel(p.deploy_status) }}</span>
             <span class="stars" v-if="p.stars">⭐ {{ p.stars }}</span>
+            <span class="forks" v-if="p.forks">🍴 {{ p.forks }}</span>
           </div>
 
           <!-- 封面 / 占位 -->
           <img v-if="p.cover_image" :src="p.cover_image" class="proj-cover" />
-          <div v-else class="proj-placeholder">{{ p.name[0].toUpperCase() }}</div>
+          <div v-else class="proj-placeholder">{{ p.name[0]?.toUpperCase() }}</div>
 
           <h3 class="proj-name">{{ p.name }}</h3>
           <p class="proj-desc text-muted">{{ p.description }}</p>
@@ -28,12 +32,23 @@
             <el-tag v-for="t in parseTags(p.tech_stack || p.tags)" :key="t" size="small" type="info">{{ t }}</el-tag>
           </div>
 
-          <!-- 操作 -->
+          <!-- 框架标识 -->
+          <div v-if="p.framework" class="fw-row">
+            <span class="fw-badge">{{ fwLabel(p.framework) }}</span>
+          </div>
+
+          <!-- 操作按钮 -->
           <div class="proj-actions">
             <a :href="p.github_url" target="_blank" class="btn btn--ghost">GitHub ↗</a>
-            <a v-if="p.deploy_status === 'running' && p.deploy_url" :href="p.deploy_url" target="_blank" class="btn btn--live">
-              🚀 访问
-            </a>
+            <a
+              v-if="p.deploy_status === 'running' && p.deploy_url"
+              :href="p.deploy_url"
+              target="_blank"
+              class="btn btn--live"
+            >🚀 访问</a>
+            <span v-else-if="p.deploy_status === 'deploying'" class="btn btn--deploying">
+              ⏳ 部署中
+            </span>
           </div>
         </div>
       </div>
@@ -41,15 +56,17 @@
       <el-empty v-if="!loading && !projects.length" description="暂无项目" style="padding:80px 0" />
 
       <div class="pager" v-if="total > pageSize">
-        <el-pagination v-model:current-page="page" :page-size="pageSize" :total="total"
-          background layout="prev,pager,next" @current-change="load" />
+        <el-pagination
+          v-model:current-page="page" :page-size="pageSize" :total="total"
+          background layout="prev,pager,next" @current-change="load"
+        />
       </div>
     </div>
   </div>
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, onUnmounted } from 'vue'
 import { projectsApi } from '@/api/endpoints.js'
 
 const projects = ref([])
@@ -57,9 +74,11 @@ const total    = ref(0)
 const page     = ref(1)
 const pageSize = 12
 const loading  = ref(false)
+let   timer    = null
 
 const parseTags   = (t) => (t || '').split(',').map(s => s.trim()).filter(Boolean)
 const statusLabel = (s) => ({ pending:'待部署', deploying:'部署中', running:'运行中', failed:'失败', stopped:'已停止' }[s] ?? s)
+const fwLabel     = (f) => ({ 'vue-react':'Vue/React', nextjs:'Next.js', nodejs:'Node.js', fastapi:'FastAPI', flask:'Flask', django:'Django', static:'静态', docker:'Docker' }[f] ?? f)
 
 async function load() {
   loading.value = true
@@ -67,46 +86,60 @@ async function load() {
     const res = await projectsApi.list({ page: page.value, page_size: pageSize })
     projects.value = res.items ?? []
     total.value    = res.total
+    // 有部署中的项目则自动轮询
+    const hasDeploying = projects.value.some(p => p.deploy_status === 'deploying')
+    if (hasDeploying && !timer) {
+      timer = setInterval(load, 5000)
+    } else if (!hasDeploying && timer) {
+      clearInterval(timer); timer = null
+    }
   } finally { loading.value = false }
 }
 
 onMounted(load)
+onUnmounted(() => { if (timer) clearInterval(timer) })
 </script>
 
 <style scoped>
 .page      { padding-top: 60px; }
 .proj-grid { display: grid; grid-template-columns: repeat(auto-fill,minmax(300px,1fr)); gap: 24px; }
-.proj-card { display: flex; flex-direction: column; gap: 12px; }
+.proj-card { display: flex; flex-direction: column; gap: 12px; overflow: hidden; padding: 0; }
 
-.proj-status { display: flex; align-items: center; gap: 8px; }
-.dot { width: 8px; height: 8px; border-radius: 50%; background: #475569; }
-.dot.running { background: #10b981; box-shadow: 0 0 8px rgba(16,185,129,.6); animation: pulse 2s infinite; }
-.dot.deploying { background: #f59e0b; animation: pulse 1s infinite; }
-.dot.failed   { background: #ef4444; }
-.status-txt { font-size: .75rem; color: #64748b; }
-.status-txt.running   { color: #10b981; }
-.status-txt.deploying { color: #f59e0b; }
-.status-txt.failed    { color: #ef4444; }
-.stars { margin-left: auto; font-size: .8125rem; color: #f59e0b; }
-
-.proj-cover {
-  width: 100%; height: 150px; object-fit: cover; border-radius: 8px;
-}
+/* 封面 */
+.proj-cover { width:100%; height:150px; object-fit:cover; }
 .proj-placeholder {
-  width: 100%; height: 100px; border-radius: 8px;
-  background: linear-gradient(135deg,#1e293b,#334155);
-  display: flex; align-items: center; justify-content: center;
-  font-size: 2.5rem; font-weight: 800; color: rgba(59,130,246,.35);
+  width:100%; height:110px;
+  background:linear-gradient(135deg,#1e293b,#334155);
+  display:flex; align-items:center; justify-content:center;
+  font-size:2.75rem; font-weight:800; color:rgba(59,130,246,.25);
 }
-.proj-name { font-size: 1rem; font-weight: 700; color: #f1f5f9; }
-.proj-desc { font-size: .875rem; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
-.tag-row   { display: flex; gap: 6px; flex-wrap: wrap; }
-.proj-actions { display: flex; gap: 10px; flex-wrap: wrap; margin-top: auto; }
 
-.btn       { display: inline-flex; align-items: center; gap: 5px; padding: 7px 14px; border-radius: 8px; font-size: .8125rem; font-weight: 600; text-decoration: none; transition: all .2s; }
-.btn--ghost { border: 1px solid #334155; color: #94a3b8; }
-.btn--ghost:hover { border-color: #60a5fa; color: #60a5fa; }
-.btn--live  { background: linear-gradient(135deg,#10b981,#059669); color: white; }
+/* 内容区 padding */
+.proj-status { display:flex; align-items:center; gap:7px; padding:14px 16px 0; }
+.proj-name   { font-size:.9375rem; font-weight:700; color:#f1f5f9; padding: 0 16px; }
+.proj-desc   { font-size:.8125rem; padding:0 16px; display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden; }
+.tag-row     { display:flex; gap:6px; flex-wrap:wrap; padding:0 16px; }
+.fw-row      { padding:0 16px; }
 
-.pager { display: flex; justify-content: center; margin-top: 48px; }
+.dot { width:8px; height:8px; border-radius:50%; background:#475569; }
+.dot.running   { background:#10b981; box-shadow:0 0 8px rgba(16,185,129,.6); animation:pulse 2s infinite; }
+.dot.deploying { background:#f59e0b; animation:pulse 1s infinite; }
+.dot.failed    { background:#ef4444; }
+.status-txt { font-size:.75rem; color:#64748b; }
+.status-txt.running   { color:#10b981; }
+.status-txt.deploying { color:#f59e0b; }
+.status-txt.failed    { color:#ef4444; }
+.stars { margin-left:auto; font-size:.8125rem; color:#f59e0b; }
+.forks { font-size:.8125rem; color:#64748b; }
+
+.fw-badge { padding:2px 8px; border-radius:4px; background:rgba(139,92,246,.12); color:#a78bfa; font-size:.75rem; }
+
+.proj-actions { display:flex; gap:8px; flex-wrap:wrap; margin-top:auto; padding:12px 16px; border-top:1px solid #1e293b; }
+.btn { display:inline-flex; align-items:center; gap:5px; padding:6px 14px; border-radius:8px; font-size:.8125rem; font-weight:600; text-decoration:none; transition:all .2s; }
+.btn--ghost   { border:1px solid #334155; color:#94a3b8; }
+.btn--ghost:hover { border-color:#60a5fa; color:#60a5fa; }
+.btn--live    { background:linear-gradient(135deg,#10b981,#059669); color:white; }
+.btn--deploying { border:1px solid #f59e0b44; color:#f59e0b; font-size:.8125rem; padding:6px 14px; border-radius:8px; }
+
+.pager { display:flex; justify-content:center; margin-top:48px; }
 </style>


### PR DESCRIPTION
## 迭代三：项目自动部署

### 后端
- `deploy.py` Celery 全流程任务：clone → 框架识别 → 安装依赖 → 构建 → 后台启动
- 支持框架：Vue/React · Next.js · Node.js · FastAPI · Flask · Django · Static · Docker
- 端口自动分配（8100~9000）
- 增量日志写入 DB，支持 offset 轮询
- PID 追踪，支持进程停止

### 新增接口
| 接口 | 说明 |
|------|------|
| `POST /projects/{id}/deploy` | 触发部署 |
| `POST /projects/{id}/redeploy` | 停止后重部署 |
| `POST /projects/{id}/stop` | 停止进程 |
| `GET  /projects/{id}/logs?offset=N` | 增量日志轮询 |
| `POST /projects/{id}/cover` | 封面图上传 |

### 前端
- **ProjectManager**：卡片 grid + 部署/重部署/停止/删除 + 日志 Drawer（2s 增量轮询）
- **ProjectsView**（公开）：运行状态绿点 + 🚀 访问按钮 + 5s 自动轮询