### PR TITLE
feat: import article from CSDN URL

### DIFF
--- a/backend/app/api/articles.py
+++ b/backend/app/api/articles.py
@@ -13,7 +13,10 @@ import uuid
 from datetime import UTC, datetime
 from typing import Optional
 
+import httpx
 from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
 from slugify import slugify
 from sqlalchemy import desc
 from sqlalchemy.orm import Session
@@ -232,6 +235,115 @@ async def upload_markdown(
     db.refresh(article)
 
     # 清除列表缓存
+    await cache.clear_pattern("articles:list:*")
+    return article
+
+
+# ── CSDN 导入 ──────────────────────────────────────────────
+
+class CsdnImportBody(BaseModel):
+    url: str
+
+def _extract_csdn(html: str, url: str) -> dict:
+    """从 CSDN 文章 HTML 中提取标题、正文（转 Markdown）、封面、摘要、标签。"""
+    # 标题
+    title_m = re.search(r'<h1[^>]*class="[^"]*title-article[^"]*"[^>]*>(.*?)</h1>', html, re.S)
+    if not title_m:
+        title_m = re.search(r'<title>(.*?)(?:\s*[-_|].*)?</title>', html, re.S)
+    title = re.sub(r'<[^>]+>', '', title_m.group(1)).strip() if title_m else "CSDN 文章"
+
+    # 封面（og:image）
+    cover_m = re.search(r'<meta[^>]+property="og:image"[^>]+content="([^"]+)"', html)
+    cover = cover_m.group(1) if cover_m else None
+
+    # 标签
+    tags_list = re.findall(r'<a[^>]+class="[^"]*tag-link[^"]*"[^>]*>([^<]+)</a>', html)
+    tags = ",".join(t.strip() for t in tags_list[:6]) if tags_list else ""
+
+    # 正文
+    body_m = re.search(
+        r'<div[^>]+id="article_content"[^>]*>(.*?)</div>\s*(?=<div[^>]+class="[^"]*article-copyright)',
+        html, re.S
+    )
+    if not body_m:
+        body_m = re.search(r'<div[^>]+id="article_content"[^>]*>(.*?)</div>', html, re.S)
+
+    content_html = body_m.group(1) if body_m else ""
+
+    # 简单 HTML → Markdown 转换
+    md = content_html
+    md = re.sub(r'<h([1-6])[^>]*>(.*?)</h\1>', lambda m: '#' * int(m.group(1)) + ' ' + re.sub(r'<[^>]+>', '', m.group(2)).strip(), md, flags=re.S)
+    md = re.sub(r'<pre[^>]*><code[^>]*class="[^"]*language-([^"\s]+)[^"]*"[^>]*>(.*?)</code></pre>',
+                lambda m: f'\n```{m.group(1)}\n{re.sub(chr(60)+"[^>]+"+chr(62),"",m.group(2)).strip()}\n```\n', md, flags=re.S)
+    md = re.sub(r'<pre[^>]*><code[^>]*>(.*?)</code></pre>',
+                lambda m: f'\n```\n{re.sub(chr(60)+"[^>]+"+chr(62),"",m.group(1)).strip()}\n```\n', md, flags=re.S)
+    md = re.sub(r'<code[^>]*>(.*?)</code>', lambda m: f'`{re.sub(chr(60)+"[^>]+"+chr(62),"",m.group(1))}`', md, flags=re.S)
+    md = re.sub(r'<strong[^>]*>(.*?)</strong>', r'**\1**', md, flags=re.S)
+    md = re.sub(r'<em[^>]*>(.*?)</em>', r'*\1*', md, flags=re.S)
+    md = re.sub(r'<a[^>]+href="([^"]+)"[^>]*>(.*?)</a>', r'[\2](\1)', md, flags=re.S)
+    md = re.sub(r'<img[^>]+src="([^"]+)"[^>]*/?>', r'![](\1)', md, flags=re.S)
+    md = re.sub(r'<li[^>]*>(.*?)</li>', r'- \1', md, flags=re.S)
+    md = re.sub(r'<[^>]+>', '', md)
+    md = re.sub(r'\n{3,}', '\n\n', md).strip()
+
+    # 追加原文链接
+    md += f'\n\n---\n> 原文链接：[{url}]({url})\n'
+
+    summary = md[:200].replace('\n', ' ').strip()
+
+    return {"title": title, "content": md, "cover": cover, "tags": tags, "summary": summary}
+
+
+@router.post(
+    "/import-csdn",
+    response_model=ArticleOut,
+    status_code=201,
+    summary="从 CSDN 链接导入文章，保存为草稿",
+)
+async def import_csdn(
+    body: CsdnImportBody,
+    db: Session = Depends(get_db),
+    admin: User = Depends(require_admin),
+    cache: CacheManager = Depends(get_cache),
+):
+    url = body.url.strip()
+    if "csdn.net" not in url:
+        raise HTTPException(400, "仅支持 CSDN 文章链接（csdn.net）")
+
+    headers = {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/122 Safari/537.36",
+        "Accept-Language": "zh-CN,zh;q=0.9",
+        "Referer": "https://blog.csdn.net/",
+    }
+    try:
+        async with httpx.AsyncClient(follow_redirects=True, timeout=12) as client:
+            resp = await client.get(url, headers=headers)
+        if resp.status_code != 200:
+            raise HTTPException(502, f"CSDN 返回 {resp.status_code}，请检查链接是否有效")
+        html = resp.text
+    except httpx.TimeoutException:
+        raise HTTPException(504, "请求 CSDN 超时，请稍后重试")
+    except httpx.RequestError as e:
+        raise HTTPException(502, f"网络错误：{e}")
+
+    meta = _extract_csdn(html, url)
+    if not meta["content"] or len(meta["content"]) < 50:
+        raise HTTPException(422, "无法提取文章内容，CSDN 可能需要登录或已更改页面结构")
+
+    slug = _unique_slug(meta["title"], db)
+    article = Article(
+        title=meta["title"],
+        slug=slug,
+        summary=meta["summary"],
+        content=meta["content"],
+        cover_image=meta["cover"],
+        tags=meta["tags"],
+        is_published=False,
+        author_id=admin.id,
+    )
+    db.add(article)
+    db.commit()
+    db.refresh(article)
     await cache.clear_pattern("articles:list:*")
     return article
 

--- a/frontend/src/api/endpoints.js
+++ b/frontend/src/api/endpoints.js
@@ -27,6 +27,7 @@ export const articlesApi = {
   uploadMd:    (fd)      => http.post('/articles/upload-md', fd, {
     headers: { 'Content-Type': 'multipart/form-data' },
   }),
+  importCsdn:  (url)     => http.post('/articles/import-csdn', { url }),
   uploadCover: (id, fd)  => http.post(`/articles/${id}/cover`, fd, {
     headers: { 'Content-Type': 'multipart/form-data' },
   }),

--- a/frontend/src/views/admin/ArticleManager.vue
+++ b/frontend/src/views/admin/ArticleManager.vue
@@ -25,6 +25,7 @@
           <el-button type="success" :icon="Upload">上传 .md</el-button>
         </el-upload>
         <el-button type="primary" :icon="Plus" @click="openEditor(null)">新建文章</el-button>
+        <el-button type="warning" :icon="Link" @click="csdnVisible = true">从 CSDN 导入</el-button>
       </div>
     </div>
 
@@ -35,8 +36,6 @@
       stripe
       style="width:100%"
       row-key="id"
-      :header-cell-style="{ background:'#1e293b', color:'#94a3b8', borderBottom:'1px solid #334155' }"
-      :cell-style="{ background:'#0f172a', color:'#e2e8f0', borderBottom:'1px solid #1e293b' }"
     >
       <el-table-column prop="id" label="ID" width="60" />
 
@@ -127,6 +126,32 @@
       />
     </el-drawer>
 
+    <!-- ── CSDN 导入 Dialog ──────────────────────────────── -->
+    <el-dialog
+      v-model="csdnVisible"
+      title="从 CSDN 导入文章"
+      width="520px"
+      :close-on-click-modal="false"
+    >
+      <div class="csdn-form">
+        <p class="csdn-tip">
+          粘贴 CSDN 文章链接，系统将自动提取标题、正文、标签并保存为草稿，同时在文末附上原文链接。
+        </p>
+        <el-input
+          v-model="csdnUrl"
+          placeholder="https://blog.csdn.net/xxx/article/details/xxx"
+          clearable
+          :prefix-icon="Link"
+          size="large"
+        />
+        <div v-if="csdnError" class="csdn-error">⚠️ {{ csdnError }}</div>
+      </div>
+      <template #footer>
+        <el-button @click="csdnVisible = false">取消</el-button>
+        <el-button type="primary" :loading="csdnLoading" @click="doImportCsdn">导入</el-button>
+      </template>
+    </el-dialog>
+
   </div>
 </template>
 
@@ -134,7 +159,7 @@
 import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { ElMessage, ElMessageBox } from 'element-plus'
-import { Search, Plus, Upload } from '@element-plus/icons-vue'
+import { Search, Plus, Upload, Link } from '@element-plus/icons-vue'
 import { articlesApi } from '@/api/endpoints.js'
 import ArticleEditor from './ArticleEditor.vue'
 import dayjs from 'dayjs'
@@ -150,6 +175,12 @@ const searchQ         = ref('')
 const filterPublished = ref(null)
 const editorVisible   = ref(false)
 const editId          = ref(null)
+
+// CSDN 导入
+const csdnVisible = ref(false)
+const csdnUrl     = ref('')
+const csdnLoading = ref(false)
+const csdnError   = ref('')
 
 const parseTags = (t) => (t || '').split(',').map(s => s.trim()).filter(Boolean)
 const fmtDate   = (d) => d ? dayjs(d).format('YYYY-MM-DD HH:mm') : '—'
@@ -218,15 +249,41 @@ async function uploadMd(file) {
   return false  // 阻止 el-upload 自动上传
 }
 
+async function doImportCsdn() {
+  csdnError.value = ''
+  const url = csdnUrl.value.trim()
+  if (!url) { csdnError.value = '请输入 CSDN 文章链接'; return }
+  if (!url.includes('csdn.net')) { csdnError.value = '请输入有效的 CSDN 链接（包含 csdn.net）'; return }
+  csdnLoading.value = true
+  try {
+    const art = await articlesApi.importCsdn(url)
+    ElMessage.success(`「${art.title}」已导入为草稿，可在编辑器中继续编辑`)
+    csdnVisible.value = false
+    csdnUrl.value = ''
+    editId.value = art.id
+    editorVisible.value = true
+    loadList()
+  } catch (e) {
+    csdnError.value = e?.response?.data?.detail || e?.message || '导入失败，请检查链接或稍后重试'
+  } finally {
+    csdnLoading.value = false
+  }
+}
+
 onMounted(loadList)
 </script>
 
 <style scoped>
 .page-head    { display:flex; justify-content:space-between; align-items:center; margin-bottom:20px; flex-wrap:wrap; gap:12px; }
-.page-h2      { font-size:1.375rem; font-weight:700; color:#f1f5f9; }
+.page-h2      { font-size:1.375rem; font-weight:700; color:var(--c-text); }
 .head-actions { display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
 .cover-thumb  { width:48px; height:36px; object-fit:cover; border-radius:4px; }
-.cover-empty  { width:48px; height:36px; display:flex; align-items:center; justify-content:center; font-size:1.25rem; background:#1e293b; border-radius:4px; }
-.article-title { font-weight:600; color:#e2e8f0; }
+.cover-empty  { width:48px; height:36px; display:flex; align-items:center; justify-content:center; font-size:1.25rem; background:var(--c-bg-card2); border-radius:4px; }
+.article-title { font-weight:600; color:var(--c-text); }
 .pager        { display:flex; justify-content:flex-end; margin-top:20px; }
+
+/* CSDN 导入弹窗 */
+.csdn-form  { display:flex; flex-direction:column; gap:14px; }
+.csdn-tip   { font-size:.875rem; color:var(--c-text-muted); line-height:1.6; }
+.csdn-error { font-size:.85rem; color:var(--c-danger); background:rgba(220,38,38,.07); padding:8px 12px; border-radius:6px; }
 </style>


### PR DESCRIPTION
## 功能：从 CSDN 链接导入文章

### 后端 `articles.py`
- 新增 `POST /articles/import-csdn`
- 接收 CSDN 文章链接，用 httpx 抓取页面
- 自动提取：标题、正文（HTML→Markdown）、封面图（og:image）、标签、摘要
- 文末自动附上原文链接
- 保存为草稿，需管理员权限

### 前端 `endpoints.js`
- 新增 `importCsdn(url)` 方法

### 管理台 `ArticleManager.vue`
- 顶栏新增「🔗 从 CSDN 导入」按钮
- 点击弹窗，输入链接 → 点导入 → 自动打开编辑器继续编辑
- 导入失败显示具体错误信息
- 顺带修复硬编码深色样式 → CSS 变量