### PR TITLE
fix: replace hardcoded dark colors in articles pages, fix cover image display

### DIFF
--- a/frontend/src/views/public/ArticleDetail.vue
+++ b/frontend/src/views/public/ArticleDetail.vue
@@ -192,17 +192,17 @@ onUnmounted(() => window.removeEventListener('scroll', onScroll))
 .art-layout { display: flex; gap: 40px; align-items: flex-start; max-width: 1100px; }
 .art-main   { flex: 1; min-width: 0; }
 
-.back-link { color: #60a5fa; font-size: .875rem; display: inline-block; margin-bottom: 28px; }
+.back-link { color: var(--c-primary); font-size: .875rem; display: inline-block; margin-bottom: 28px; }
 .back-link:hover { text-decoration: underline; }
 
 .art-header { margin-bottom: 40px; }
 .tag-row    { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 14px; }
-.art-title  { font-size: clamp(1.75rem,4vw,2.5rem); font-weight: 800; color: #f1f5f9; line-height: 1.25; margin-bottom: 14px; }
-.art-meta   { display: flex; gap: 24px; color: #64748b; font-size: .875rem; margin-bottom: 22px; flex-wrap: wrap; }
-.art-cover  { width: 100%; max-height: 380px; object-fit: cover; border-radius: 12px; margin-top: 8px; }
+.art-title  { font-size: clamp(1.75rem,4vw,2.5rem); font-weight: 800; color: var(--c-text); line-height: 1.25; margin-bottom: 14px; }
+.art-meta   { display: flex; gap: 24px; color: var(--c-text-muted); font-size: .875rem; margin-bottom: 22px; flex-wrap: wrap; }
+.art-cover  { width: 100%; max-height: 380px; object-fit: cover; border-radius: 12px; margin-top: 8px; display: block; }
 
-.art-nav     { display: flex; justify-content: flex-start; margin-top: 48px; padding-top: 24px; border-top: 1px solid #1e293b; }
-.art-nav-btn { color: #60a5fa; font-size: .875rem; }
+.art-nav     { display: flex; justify-content: flex-start; margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--c-border); }
+.art-nav-btn { color: var(--c-primary); font-size: .875rem; }
 .art-nav-btn:hover { text-decoration: underline; }
 
 /* 目录 */
@@ -211,11 +211,11 @@ onUnmounted(() => window.removeEventListener('scroll', onScroll))
   position: sticky; top: 80px;
   max-height: calc(100vh - 100px); overflow-y: auto;
 }
-.toc-title { font-size: .8rem; font-weight: 700; color: #60a5fa; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 12px; }
+.toc-title { font-size: .8rem; font-weight: 700; color: var(--c-primary); letter-spacing: .08em; text-transform: uppercase; margin-bottom: 12px; }
 .toc-nav   { display: flex; flex-direction: column; gap: 2px; }
-.toc-item  { font-size: .8125rem; color: #64748b; text-decoration: none; padding: 4px 8px; border-radius: 5px; transition: all .15s; line-height: 1.5; }
-.toc-item:hover  { color: #e2e8f0; background: #1e293b; }
-.toc-item.active { color: #60a5fa; background: rgba(59,130,246,.1); }
+.toc-item  { font-size: .8125rem; color: var(--c-text-muted); text-decoration: none; padding: 4px 8px; border-radius: 5px; transition: all .15s; line-height: 1.5; }
+.toc-item:hover  { color: var(--c-text); background: var(--c-bg-card2); }
+.toc-item.active { color: var(--c-primary); background: rgba(59,111,212,.08); }
 .toc-h1 { font-weight: 700; }
 .toc-h2 { padding-left: 8px; }
 .toc-h3 { padding-left: 20px; font-size: .78rem; }

--- a/frontend/src/views/public/ArticlesView.vue
+++ b/frontend/src/views/public/ArticlesView.vue
@@ -102,12 +102,19 @@ onMounted(load)
 .page { padding-top: 60px; }
 .tag-filter { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 36px; }
 .art-grid { display: grid; grid-template-columns: repeat(auto-fill,minmax(300px,1fr)); gap: 24px; }
-.art-card { display: flex; flex-direction: column; text-decoration: none; color: inherit; overflow: hidden; padding: 0; }
-.art-cover { width: 100%; height: 170px; object-fit: cover; }
+.art-card {
+  display: flex; flex-direction: column; text-decoration: none;
+  color: inherit; overflow: hidden; padding: 0;
+}
+.art-cover {
+  width: 100%; height: 170px; object-fit: cover;
+  display: block; /* 消除图片底部间隙 */
+  background: var(--c-bg-2); /* 图片加载前的占位色 */
+}
 .art-body { padding: 20px; flex: 1; display: flex; flex-direction: column; gap: 10px; }
 .tag-row { display: flex; gap: 6px; flex-wrap: wrap; }
-.art-title { font-size: 1rem; font-weight: 700; color: #f1f5f9; line-height: 1.4; }
-.art-sum { font-size: .875rem; flex: 1; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
-.art-foot { display: flex; justify-content: space-between; font-size: .8125rem; color: #64748b; padding-top: 8px; border-top: 1px solid #1e293b; }
+.art-title { font-size: 1rem; font-weight: 700; color: var(--c-text); line-height: 1.4; }
+.art-sum { font-size: .875rem; color: var(--c-text-muted); flex: 1; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
+.art-foot { display: flex; justify-content: space-between; font-size: .8125rem; color: var(--c-text-muted); padding-top: 8px; border-top: 1px solid var(--c-border); }
 .pager { display: flex; justify-content: center; margin-top: 48px; }
 </style>


### PR DESCRIPTION
## 问题修复

### ArticlesView.vue（文章列表页）
- `art-title`：`#f1f5f9` → `var(--c-text)`，浅色主题下文字清晰可见
- `art-sum`：补上 `color: var(--c-text-muted)` 使摘要文字正常显示
- `art-foot`：边框 `#1e293b` 和颜色 `#64748b` → CSS 变量
- `art-cover`：补 `display: block` 消除底部间隙，加 `background: var(--c-bg-2)` 作图片加载占位

### ArticleDetail.vue（文章详情页）
- `art-title`、`art-meta`、`art-nav`、`back-link` 等所有硬编码颜色 → CSS 变量
- 目录 TOC：`toc-item` hover/active 颜色跟随主题
- `art-cover`：补 `display: block`