### PR TITLE
fix: fix code block colors for light theme in article preview

### DIFF
--- a/frontend/src/assets/global.css
+++ b/frontend/src/assets/global.css
@@ -30,6 +30,11 @@
   --shadow:      0 4px 24px rgba(60,80,180,.10);
   --shadow-glow: 0 0 30px rgba(59,111,212,.13), 0 8px 24px rgba(60,80,180,.08);
   --t:           .28s cubic-bezier(.4,0,.2,1);
+  /* code blocks — light */
+  --c-code-bg:         rgba(60, 80, 160, 0.08);
+  --c-code-text:       #1d4ed8;
+  --c-code-block-bg:   #f0f4ff;
+  --c-code-block-text: #1a2150;
   color-scheme: light;
 }
 
@@ -58,6 +63,11 @@
   --grad-hero:    linear-gradient(135deg, #5b8dee 0%, #a78bfa 50%, #f472b6 100%);
   --shadow:      0 8px 40px rgba(0,0,0,.6);
   --shadow-glow: 0 0 40px rgba(91,141,238,.25), 0 8px 32px rgba(0,0,0,.5);
+  /* code blocks — dark */
+  --c-code-bg:         rgba(0, 0, 0, 0.35);
+  --c-code-text:       #f6c177;
+  --c-code-block-bg:   rgba(0, 0, 0, 0.45);
+  --c-code-block-text: #e2e8f0;
   color-scheme: dark;
 }
 
@@ -186,17 +196,17 @@ a:hover { color: var(--c-accent); }
   color: var(--c-text-muted);
 }
 .md-body code {
-  background: rgba(0,0,0,.3); color: #f6c177;
+  background: var(--c-code-bg); color: var(--c-code-text);
   padding: 2px 7px; border-radius: 5px;
   font-family: 'JetBrains Mono','Fira Code',monospace; font-size: .875em;
 }
 .md-body pre {
-  background: rgba(0,0,0,.4);
+  background: var(--c-code-block-bg);
   border: 1px solid var(--c-border);
   border-radius: 10px; padding: 18px;
   overflow-x: auto; margin: 1em 0;
 }
-.md-body pre code { background: none; padding: 0; color: inherit; }
+.md-body pre code { background: none; padding: 0; color: var(--c-code-block-text); }
 .md-body img  { max-width: 100%; border-radius: 10px; }
 .md-body table { border-collapse: collapse; width: 100%; margin: 1em 0; }
 .md-body th,.md-body td { border: 1px solid var(--c-border); padding: 9px 14px; }


### PR DESCRIPTION
## 问题

文章预览页 ` ``` ` 包裹的代码块在浅色主题下看不清：
- 行内 `code`：背景 `rgba(0,0,0,.3)` 黑色 + 字色 `#f6c177` 橙色 → 浅色主题下对比度极差
- 代码块 `pre`：背景 `rgba(0,0,0,.4)` 黑色 → 同样问题

## 修复

新增 4 个 CSS 变量，浅色/深色主题各自定义：

| 变量 | 浅色 | 深色 |
|---|---|---|
| `--c-code-bg` | `rgba(60,80,160,.08)` | `rgba(0,0,0,.35)` |
| `--c-code-text` | `#1d4ed8` （深蓝） | `#f6c177` （橙） |
| `--c-code-block-bg` | `#f0f4ff` | `rgba(0,0,0,.45)` |
| `--c-code-block-text` | `#1a2150` | `#e2e8f0` |

`.md-body code / pre` 改用这些变量，深色主题效果不变。