### PR TITLE
feat: add CSDN profile link and homepage button

### DIFF
--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -22,6 +22,7 @@ class User(Base):
     github_url = Column(String(256))
     linkedin_url = Column(String(256))
     website_url = Column(String(256))
+    csdn_url = Column(String(256))
     location = Column(String(128))
     email_public = Column(String(128))
 

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -16,6 +16,7 @@ class PublicProfileOut(BaseModel):
     github_url: Optional[str] = None
     linkedin_url: Optional[str] = None
     website_url: Optional[str] = None
+    csdn_url: Optional[str] = None
     location: Optional[str] = None
     email_public: Optional[str] = None
     resume_data: Optional[str] = None
@@ -38,6 +39,7 @@ class UserOut(BaseModel):
     github_url: Optional[str] = None
     linkedin_url: Optional[str] = None
     website_url: Optional[str] = None
+    csdn_url: Optional[str] = None
     location: Optional[str] = None
     email_public: Optional[str] = None
     resume_data: Optional[str] = None
@@ -54,6 +56,7 @@ class UserProfileUpdate(BaseModel):
     github_url: Optional[str] = None
     linkedin_url: Optional[str] = None
     website_url: Optional[str] = None
+    csdn_url: Optional[str] = None
     location: Optional[str] = None
     email_public: Optional[str] = None
     resume_data: Optional[str] = None

--- a/frontend/src/views/admin/ProfileEditor.vue
+++ b/frontend/src/views/admin/ProfileEditor.vue
@@ -45,6 +45,14 @@
           </el-form-item>
         </el-col>
         <el-col :span="8">
+          <el-form-item label="CSDN 主页">
+            <el-input v-model="form.csdn_url" placeholder="https://blog.csdn.net/xxx" />
+          </el-form-item>
+        </el-col>
+      </el-row>
+
+      <el-row :gutter="20">
+        <el-col :span="8">
           <el-form-item label="头像 URL">
             <el-input v-model="form.avatar_url" placeholder="https://..." />
           </el-form-item>
@@ -80,7 +88,7 @@ const loading = ref(false)
 const saving  = ref(false)
 const form    = ref({
   full_name: '', title: '', bio: '', location: '', email_public: '',
-  github_url: '', linkedin_url: '', avatar_url: '', resume_data: '',
+  github_url: '', linkedin_url: '', csdn_url: '', avatar_url: '', resume_data: '',
 })
 
 onMounted(async () => {

--- a/frontend/src/views/public/HomeView.vue
+++ b/frontend/src/views/public/HomeView.vue
@@ -75,6 +75,12 @@
               </svg>
               LinkedIn
             </a>
+            <a v-if="profile?.csdn_url" :href="profile.csdn_url" target="_blank" class="btn btn--outline btn--csdn">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 14H9V8h2v8zm4 0h-2V8h2v8z"/>
+              </svg>
+              CSDN
+            </a>
             <router-link to="/articles" class="btn btn--primary">
               <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-5 14H7v-2h7v2zm3-4H7v-2h10v2zm0-4H7V7h10v2z"/>
@@ -593,6 +599,16 @@ onMounted(async () => {
   box-shadow: 0 8px 28px rgba(91,141,238,.45);
 }
 .btn--gradient > * { position: relative; z-index: 1; }
+.btn--csdn {
+  border-color: rgba(252, 100, 30, 0.35) !important;
+  color: #fc641e !important;
+  background: rgba(252, 100, 30, 0.06) !important;
+}
+.btn--csdn:hover {
+  border-color: rgba(252, 100, 30, 0.6) !important;
+  background: rgba(252, 100, 30, 0.14) !important;
+  box-shadow: 0 6px 20px rgba(252, 100, 30, 0.2) !important;
+}
 
 /* 统计 */
 .hero__stats {


### PR DESCRIPTION
## 功能：首页 CSDN 跳转按钮

### 改动

**后端**
- `models/user.py`：新增 `csdn_url` 字段（`String(256)`）
- `schemas/user.py`：`PublicProfileOut`、`UserOut`、`UserProfileUpdate` 三个类均新增 `csdn_url: Optional[str]`

**管理台 `ProfileEditor.vue`**
- 社交链接区新增「CSDN 主页」输入框
- `form` 初始化加入 `csdn_url`

**首页 `HomeView.vue`**
- Hero 区按钮组新增 CSDN 按钮（`v-if="profile?.csdn_url"`，未配置时不显示）
- 使用 CSDN 橙色品牌色（`#fc641e`）单独样式 `.btn--csdn`，与其他按钮区分