### PR TITLE
fix: article cover upload unresponsive

### DIFF
--- a/frontend/src/views/admin/ArticleEditor.vue
+++ b/frontend/src/views/admin/ArticleEditor.vue
@@ -33,7 +33,9 @@
                 <el-upload
                   :show-file-list="false"
                   accept="image/*"
-                  :before-upload="uploadCover"
+                  action="#"
+                  :auto-upload="false"
+                  :on-change="(f) => uploadCover(f.raw)"
                   class="cover-upload"
                 >
                   <div class="cover-overlay">更换</div>
@@ -188,10 +190,10 @@ async function save() {
 
 // ── 封面图上传 ────────────────────────────────────────────
 async function uploadCover(file) {
+  if (!file) return
   if (!props.articleId) {
-    // 先保存一下文章再上传封面
     ElMessage.info('请先保存文章，再上传封面图')
-    return false
+    return
   }
   const fd = new FormData()
   fd.append('file', file)
@@ -200,7 +202,6 @@ async function uploadCover(file) {
     form.value.cover_image = res.cover_image
     ElMessage.success('封面已更新')
   } catch { ElMessage.error('封面上传失败') }
-  return false
 }
 
 // ── 重新导入 .md ──────────────────────────────────────────
@@ -269,7 +270,8 @@ function onInput() { /* 预览通过 computed 自动更新 */ }
 .cover-box      { position: relative; width: 120px; height: 80px; cursor: pointer; border-radius: 8px; overflow: hidden; background: #1e293b; }
 .cover-preview  { width: 100%; height: 100%; object-fit: cover; }
 .cover-placeholder { width: 100%; height: 100%; display: flex; align-items: center; justify-content: center; font-size: .8125rem; color: #64748b; }
-.cover-upload   { position: absolute; inset: 0; opacity: 0; }
+.cover-upload   { position: absolute; inset: 0; opacity: 0; width: 100%; height: 100%; }
+.cover-upload :deep(.el-upload) { width: 100%; height: 100%; display: block; }
 .cover-overlay  { width: 100%; height: 100%; }
 
 /* MD 编辑器 */


### PR DESCRIPTION
## 问题

文章编辑器的封面上传区域点击无响应。

## 根因

`el-upload` 缺少 `action` 属性，点击时 Element Plus 内部尝试向当前 URL 发空 POST，触发异常导致 drawer 无响应；同时 `.el-upload` 内部元素未撑满 cover-box，可点击热区实际为空。

## 修复

- 添加 `action="#"` + `auto-upload: false`，阻止内部自动请求
- 用 `on-change` 替换 `before-upload`，直接取 `f.raw` 手动调接口，更可靠
- `.cover-upload :deep(.el-upload)` 设 `width/height: 100%; display: block`，保证点击热区覆盖整个封面框

## 文件

- `frontend/src/views/admin/ArticleEditor.vue`