### PR TITLE
refactor: 去掉 AI 写作助手面板，新增醒目引导弹窗

### DIFF
--- a/frontend/src/layouts/PublicLayout.vue
+++ b/frontend/src/layouts/PublicLayout.vue
@@ -107,27 +107,22 @@
     </main>
 
     <!-- ── AI 助手悬浮入口 ──────────────────────────── -->
+    <!-- 悬浮按钮 -->
     <transition name="fab-pop">
-      <div class="ai-fab-wrap" v-if="!aiOpen">
+      <div class="ai-fab-wrap">
         <!-- Tooltip 气泡 -->
         <transition name="tooltip-fade">
           <div class="ai-tooltip" v-if="showTooltip">
-            <span>✨ 试试 AI 助手，帮你写文章、优化内容！</span>
+            <span>🤖 AI 助手已就绪，点击了解更多！</span>
             <button class="tooltip-close" @click.stop="dismissTooltip">✕</button>
           </div>
         </transition>
-        <!-- 悬浮按钮 -->
-        <button class="ai-fab" @click="openAI" aria-label="打开 AI 助手">
-          <svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor">
-            <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 14H9V8h2v8zm4 0h-2V8h2v8z"/>
-            <path d="M9 8h2v8H9zm4 0h2v8h-2z" fill="none"/>
-            <circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-width="0"/>
-          </svg>
-          <svg class="ai-fab-icon" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
-            <circle cx="9"  cy="10" r="1" fill="currentColor"/>
-            <circle cx="12" cy="10" r="1" fill="currentColor"/>
-            <circle cx="15" cy="10" r="1" fill="currentColor"/>
+        <button class="ai-fab" @click="openAI" aria-label="打开 AI 助手引导">
+          <span class="ai-fab-glow"></span>
+          <svg class="ai-fab-icon" width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M12 2a2 2 0 0 1 2 2c0 .74-.4 1.39-1 1.73V7h1a7 7 0 0 1 7 7h1a1 1 0 0 1 1 1v3a1 1 0 0 1-1 1h-1v1a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-1H2a1 1 0 0 1-1-1v-3a1 1 0 0 1 1-1h1a7 7 0 0 1 7-7h1V5.73c-.6-.34-1-.99-1-1.73a2 2 0 0 1 2-2z"/>
+            <circle cx="9" cy="14" r="1" fill="currentColor" stroke="none"/>
+            <circle cx="15" cy="14" r="1" fill="currentColor" stroke="none"/>
           </svg>
           <span class="ai-fab-label">AI 助手</span>
           <span class="ai-fab-dot" v-if="showTooltip"></span>
@@ -135,10 +130,69 @@
       </div>
     </transition>
 
-    <!-- AI 助手面板 -->
-    <transition name="panel-slide">
-      <div class="ai-panel-wrap" v-if="aiOpen">
-        <AIAssistant @close="aiOpen = false" />
+    <!-- AI 助手引导弹窗 -->
+    <transition name="modal-fade">
+      <div class="ai-modal-overlay" v-if="aiOpen" @click.self="aiOpen = false">
+        <transition name="modal-pop">
+          <div class="ai-modal" v-if="aiOpen">
+            <button class="ai-modal-close" @click="aiOpen = false">✕</button>
+
+            <!-- 头部 -->
+            <div class="ai-modal-header">
+              <div class="ai-modal-avatar">
+                <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M12 2a2 2 0 0 1 2 2c0 .74-.4 1.39-1 1.73V7h1a7 7 0 0 1 7 7h1a1 1 0 0 1 1 1v3a1 1 0 0 1-1 1h-1v1a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-1H2a1 1 0 0 1-1-1v-3a1 1 0 0 1 1-1h1a7 7 0 0 1 7-7h1V5.73c-.6-.34-1-.99-1-1.73a2 2 0 0 1 2-2z"/>
+                  <circle cx="9" cy="14" r="1" fill="white" stroke="none"/>
+                  <circle cx="15" cy="14" r="1" fill="white" stroke="none"/>
+                </svg>
+              </div>
+              <div>
+                <h2 class="ai-modal-title">✨ AI 助手</h2>
+                <p class="ai-modal-subtitle">你的智能写作伙伴，随时待命</p>
+              </div>
+            </div>
+
+            <!-- 功能列表 -->
+            <div class="ai-modal-features">
+              <div class="ai-feature-item">
+                <span class="ai-feature-icon">📝</span>
+                <div>
+                  <strong>文章生成</strong>
+                  <p>输入主题，一键生成高质量文章草稿</p>
+                </div>
+              </div>
+              <div class="ai-feature-item">
+                <span class="ai-feature-icon">🔧</span>
+                <div>
+                  <strong>内容优化</strong>
+                  <p>润色文字，提升清晰度与可读性</p>
+                </div>
+              </div>
+              <div class="ai-feature-item">
+                <span class="ai-feature-icon">✅</span>
+                <div>
+                  <strong>语法检查</strong>
+                  <p>智能检测语法问题，给出修改建议</p>
+                </div>
+              </div>
+              <div class="ai-feature-item">
+                <span class="ai-feature-icon">🔍</span>
+                <div>
+                  <strong>内容分析</strong>
+                  <p>自动提取关键词、摘要与情感倾向</p>
+                </div>
+              </div>
+            </div>
+
+            <!-- CTA -->
+            <div class="ai-modal-actions">
+              <router-link to="/login" class="ai-modal-btn-primary" @click="aiOpen = false">
+                立即使用 AI 助手 →
+              </router-link>
+              <button class="ai-modal-btn-secondary" @click="aiOpen = false">稍后再说</button>
+            </div>
+          </div>
+        </transition>
       </div>
     </transition>
 
@@ -200,7 +254,6 @@ import { useAuthStore } from '@/store/auth.js'
 import SearchModal from '@/components/SearchModal.vue'
 import ThemeSwitcher from '@/components/ThemeSwitcher.vue'
 import LanguageSwitcher from '@/components/LanguageSwitcher.vue'
-import AIAssistant from '@/components/AIAssistant.vue'
 
 const auth     = useAuthStore()
 const profile  = ref(null)
@@ -469,33 +522,52 @@ onUnmounted(() => {
   position: relative;
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 10px 18px 10px 14px;
+  gap: 10px;
+  padding: 14px 22px 14px 18px;
   background: linear-gradient(135deg, #5b8dee, #a78bfa);
   color: #fff;
   border: none;
   border-radius: 50px;
   cursor: pointer;
-  font-size: .875rem;
-  font-weight: 600;
-  box-shadow: 0 4px 20px rgba(91, 141, 238, 0.45);
+  font-size: .9375rem;
+  font-weight: 700;
+  box-shadow: 0 6px 24px rgba(91, 141, 238, 0.5), 0 2px 8px rgba(0,0,0,.15);
   transition: transform .2s ease, box-shadow .2s ease;
   white-space: nowrap;
+  letter-spacing: .02em;
 }
 .ai-fab:hover {
-  transform: translateY(-3px) scale(1.03);
-  box-shadow: 0 8px 28px rgba(91, 141, 238, 0.55);
+  transform: translateY(-4px) scale(1.04);
+  box-shadow: 0 12px 36px rgba(91, 141, 238, 0.6), 0 4px 12px rgba(0,0,0,.2);
 }
+
+/* 光晕动画 */
+.ai-fab-glow {
+  position: absolute;
+  inset: -2px;
+  border-radius: 50px;
+  background: linear-gradient(135deg, #5b8dee, #a78bfa);
+  opacity: .4;
+  filter: blur(10px);
+  animation: glow-pulse 2.5s ease-in-out infinite;
+  pointer-events: none;
+  z-index: -1;
+}
+@keyframes glow-pulse {
+  0%, 100% { opacity: .3; transform: scale(1); }
+  50%       { opacity: .6; transform: scale(1.06); }
+}
+
 .ai-fab-icon { flex-shrink: 0; }
-.ai-fab-label { letter-spacing: .02em; }
+.ai-fab-label { letter-spacing: .04em; }
 
 /* 红点提示 */
 .ai-fab-dot {
   position: absolute;
-  top: 6px;
-  right: 8px;
-  width: 8px;
-  height: 8px;
+  top: 8px;
+  right: 10px;
+  width: 9px;
+  height: 9px;
   background: #ff4d4f;
   border-radius: 50%;
   border: 2px solid #fff;
@@ -503,11 +575,12 @@ onUnmounted(() => {
 }
 @keyframes dot-pulse {
   0%, 100% { transform: scale(1); opacity: 1; }
-  50%       { transform: scale(1.3); opacity: .7; }
+  50%       { transform: scale(1.35); opacity: .7; }
 }
 
 /* Tooltip 气泡 */
 .ai-tooltip {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 10px;
@@ -527,12 +600,11 @@ onUnmounted(() => {
   color: #1a2035;
   box-shadow: 0 6px 24px rgba(60, 80, 180, 0.12);
 }
-/* 小箭头 */
 .ai-tooltip::after {
   content: '';
   position: absolute;
   bottom: -7px;
-  right: 22px;
+  right: 24px;
   width: 12px;
   height: 12px;
   background: var(--bg-secondary, #1a2035);
@@ -540,32 +612,170 @@ onUnmounted(() => {
   border-bottom: 1px solid rgba(91, 141, 238, 0.3);
   transform: rotate(45deg);
 }
-[data-theme="light"] .ai-tooltip::after {
-  background: #fff;
-}
+[data-theme="light"] .ai-tooltip::after { background: #fff; }
 .tooltip-close {
-  background: none;
-  border: none;
+  background: none; border: none;
   color: var(--c-text-muted, #8899b0);
-  cursor: pointer;
-  font-size: 12px;
-  padding: 0;
-  flex-shrink: 0;
-  line-height: 1;
+  cursor: pointer; font-size: 12px;
+  padding: 0; flex-shrink: 0; line-height: 1;
   transition: color .15s;
 }
 .tooltip-close:hover { color: var(--c-text, #e0e6f0); }
 
-/* AI 面板定位包裹 */
-.ai-panel-wrap {
+/* ── AI 引导弹窗 ──────────────────────────────────────── */
+.ai-modal-overlay {
   position: fixed;
-  bottom: 28px;
-  right: 28px;
-  z-index: 200;
+  inset: 0;
+  z-index: 300;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+
+.ai-modal {
+  position: relative;
+  width: 100%;
+  max-width: 460px;
+  background: var(--bg-secondary, #151d30);
+  border: 1px solid rgba(91, 141, 238, 0.25);
+  border-radius: 20px;
+  padding: 32px 28px 28px;
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(255,255,255,.04);
+  overflow: hidden;
+}
+[data-theme="light"] .ai-modal {
+  background: #fff;
+  border-color: rgba(91, 141, 238, 0.2);
+  box-shadow: 0 24px 64px rgba(60, 80, 180, 0.15);
+}
+.ai-modal::before {
+  content: '';
+  position: absolute;
+  top: -60px; left: 50%; transform: translateX(-50%);
+  width: 300px; height: 160px;
+  background: radial-gradient(ellipse, rgba(91,141,238,.18) 0%, transparent 70%);
+  pointer-events: none;
+}
+
+.ai-modal-close {
+  position: absolute;
+  top: 14px; right: 16px;
+  background: none; border: none;
+  color: var(--c-text-muted, #8899b0);
+  cursor: pointer; font-size: 16px;
+  width: 28px; height: 28px;
+  display: flex; align-items: center; justify-content: center;
+  border-radius: 6px;
+  transition: background .15s, color .15s;
+}
+.ai-modal-close:hover {
+  background: rgba(91,141,238,.1);
+  color: var(--c-text, #e0e6f0);
+}
+
+.ai-modal-header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+.ai-modal-avatar {
+  flex-shrink: 0;
+  width: 60px; height: 60px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, #5b8dee, #a78bfa);
+  display: flex; align-items: center; justify-content: center;
+  box-shadow: 0 6px 20px rgba(91,141,238,.4);
+}
+.ai-modal-title {
+  font-size: 1.3rem;
+  font-weight: 800;
+  margin: 0 0 4px;
+  background: linear-gradient(135deg, #7aadff, #c4a8ff);
+  -webkit-background-clip: text; -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+.ai-modal-subtitle {
+  font-size: .875rem;
+  color: var(--c-text-muted, #8899b0);
+  margin: 0;
+}
+
+.ai-modal-features {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin-bottom: 28px;
+}
+.ai-feature-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  padding: 12px 14px;
+  background: rgba(91, 141, 238, 0.06);
+  border: 1px solid rgba(91, 141, 238, 0.12);
+  border-radius: 12px;
+  transition: background .2s;
+}
+.ai-feature-item:hover { background: rgba(91, 141, 238, 0.1); }
+[data-theme="light"] .ai-feature-item {
+  background: rgba(91, 141, 238, 0.05);
+  border-color: rgba(91, 141, 238, 0.15);
+}
+.ai-feature-icon { font-size: 1.25rem; flex-shrink: 0; margin-top: 1px; }
+.ai-feature-item strong {
+  display: block;
+  font-size: .9rem; font-weight: 700;
+  color: var(--c-text, #e0e6f0);
+  margin-bottom: 3px;
+}
+[data-theme="light"] .ai-feature-item strong { color: #1a2035; }
+.ai-feature-item p {
+  margin: 0;
+  font-size: .8125rem;
+  color: var(--c-text-muted, #8899b0);
+  line-height: 1.5;
+}
+
+.ai-modal-actions { display: flex; gap: 10px; }
+.ai-modal-btn-primary {
+  flex: 1;
+  display: flex; align-items: center; justify-content: center;
+  padding: 12px 20px;
+  background: linear-gradient(135deg, #5b8dee, #a78bfa);
+  color: #fff;
+  border-radius: 12px;
+  font-size: .9rem; font-weight: 700;
+  text-decoration: none;
+  box-shadow: 0 4px 16px rgba(91,141,238,.4);
+  transition: transform .2s, box-shadow .2s;
+}
+.ai-modal-btn-primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(91,141,238,.5);
+}
+.ai-modal-btn-secondary {
+  padding: 12px 18px;
+  background: none;
+  border: 1px solid var(--c-border, rgba(99,130,200,.2));
+  color: var(--c-text-muted, #8899b0);
+  border-radius: 12px;
+  font-size: .875rem;
+  cursor: pointer;
+  transition: background .2s, color .2s, border-color .2s;
+  white-space: nowrap;
+}
+.ai-modal-btn-secondary:hover {
+  background: rgba(91,141,238,.08);
+  color: var(--c-text, #e0e6f0);
+  border-color: rgba(91,141,238,.3);
 }
 
 /* ── 动画 ────────────────────────────────────────────── */
-.fab-pop-enter-active    { transition: all .3s cubic-bezier(.34,1.56,.64,1); }
+.fab-pop-enter-active    { transition: all .35s cubic-bezier(.34,1.56,.64,1); }
 .fab-pop-leave-active    { transition: all .2s ease; }
 .fab-pop-enter-from,
 .fab-pop-leave-to        { opacity: 0; transform: scale(.7) translateY(16px); }
@@ -575,14 +785,19 @@ onUnmounted(() => {
 .tooltip-fade-enter-from,
 .tooltip-fade-leave-to     { opacity: 0; transform: translateY(8px); }
 
-.panel-slide-enter-active { transition: all .3s cubic-bezier(.34,1.56,.64,1); }
-.panel-slide-leave-active { transition: all .2s ease; }
-.panel-slide-enter-from,
-.panel-slide-leave-to     { opacity: 0; transform: scale(.92) translateY(20px); }
+.modal-fade-enter-active, .modal-fade-leave-active { transition: opacity .25s ease; }
+.modal-fade-enter-from, .modal-fade-leave-to       { opacity: 0; }
+
+.modal-pop-enter-active { transition: all .35s cubic-bezier(.34,1.56,.64,1); }
+.modal-pop-leave-active { transition: all .2s ease; }
+.modal-pop-enter-from,
+.modal-pop-leave-to     { opacity: 0; transform: scale(.88) translateY(24px); }
 
 @media (max-width: 480px) {
-  .ai-fab-wrap, .ai-panel-wrap { right: 16px; bottom: 20px; }
+  .ai-fab-wrap { right: 16px; bottom: 20px; }
   .ai-fab-label { display: none; }
-  .ai-fab { padding: 12px; border-radius: 50%; }
+  .ai-fab { padding: 14px; border-radius: 50%; }
+  .ai-modal { padding: 24px 18px 20px; }
+  .ai-modal-actions { flex-direction: column; }
 }
 </style>


### PR DESCRIPTION
## 变更说明

### 问题
AI 助手入口太小，用户发现不了。

### 解决方案
去掉 AIAssistant 写作助手小面板，改为更醒目的悬浮按钮 + 全屏引导弹窗。

### 改动内容（`frontend/src/layouts/PublicLayout.vue`）

**移除：**
- `AIAssistant.vue` 写作面板（点击后不再展开小面板）
- `AIAssistant` import

**新增/升级：**
- **FAB 按钮升级**：更大尺寸、更粗字体 + 常亮**光晕呼吸动画**（glow-pulse），大幅提升视觉显著度
- **引导弹窗**：点击 FAB 弹出全屏遮罩 + 居中弹窗
  - 展示 4 个 AI 功能卡片：📝 文章生成 / 🔧 内容优化 / ✅ 语法检查 / 🔍 内容分析
  - CTA 主按钮直接跳转登录页引导使用
  - 点击遮罩 / 关闭按钮 / 「稍后再说」均可关闭
- **Tooltip 气泡**保留，2s 后自动弹出，localStorage 持久化关闭状态
- **移动端适配**：FAB 缩为圆形图标，弹窗按钮竖排