### PR TITLE
feat: connect playground and community pages to router and nav

### DIFF
--- a/frontend/src/layouts/PublicLayout.vue
+++ b/frontend/src/layouts/PublicLayout.vue
@@ -36,6 +36,12 @@
           <router-link to="/projects" class="nav__link">
             <span>{{ $t('nav.projects') }}</span>
           </router-link>
+          <router-link to="/playground" class="nav__link">
+            <span>⚡ {{ $t('nav.playground') }}</span>
+          </router-link>
+          <router-link to="/community" class="nav__link">
+            <span>🎉 {{ $t('nav.community') }}</span>
+          </router-link>
           <router-link v-if="auth.isLoggedIn" to="/admin" class="nav__admin-btn">
             <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor" style="opacity:.8">
               <path d="M12 2a5 5 0 1 0 0 10A5 5 0 0 0 12 2zm0 12c-5.33 0-8 2.67-8 4v2h16v-2c0-1.33-2.67-4-8-4z"/>
@@ -84,6 +90,14 @@
           <router-link to="/projects" class="nav__mobile-link">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" opacity=".7"><path d="M20 6h-2.18c.07-.44.18-.88.18-1.36 0-2.55-2.08-4.64-4.64-4.64-1.37 0-2.58.58-3.44 1.51L9 3.5 8.08 2.51C7.22 1.58 6.01 1 4.64 1 2.09 1 0 3.09 0 5.64c0 .48.11.92.18 1.36H0v2h20V6z"/></svg>
             {{ $t('nav.projects') }}
+          </router-link>
+          <router-link to="/playground" class="nav__mobile-link">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" opacity=".7"><path d="M9.4 16.6L4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0l4.6-4.6-4.6-4.6L16 6l6 6-6 6-1.4-1.4z"/></svg>
+            ⚡ {{ $t('nav.playground') }}
+          </router-link>
+          <router-link to="/community" class="nav__mobile-link">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" opacity=".7"><path d="M16 11c1.66 0 2.99-1.34 2.99-3S17.66 5 16 5c-1.66 0-3 1.34-3 3s1.34 3 3 3zm-8 0c1.66 0 2.99-1.34 2.99-3S9.66 5 8 5C6.34 5 5 6.34 5 8s1.34 3 3 3zm0 2c-2.33 0-7 1.17-7 3.5V19h14v-2.5c0-2.33-4.67-3.5-7-3.5zm8 0c-.29 0-.62.02-.97.05 1.16.84 1.97 1.97 1.97 3.45V19h6v-2.5c0-2.33-4.67-3.5-7-3.5z"/></svg>
+            🎉 {{ $t('nav.community') }}
           </router-link>
           <router-link v-if="auth.isLoggedIn" to="/admin" class="nav__mobile-link">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" opacity=".7"><path d="M12 2a5 5 0 1 0 0 10A5 5 0 0 0 12 2zm0 12c-5.33 0-8 2.67-8 4v2h16v-2c0-1.33-2.67-4-8-4z"/></svg>

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -74,7 +74,9 @@
   "nav": {
     "home": "Home",
     "articles": "Articles",
-    "projects": "Projects"
+    "projects": "Projects",
+    "playground": "Playground",
+    "community": "Community"
   },
   "search": {
     "placeholder": "Search articles, projects...",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -74,7 +74,9 @@
   "nav": {
     "home": "首页",
     "articles": "文章",
-    "projects": "项目"
+    "projects": "项目",
+    "playground": "代码运行",
+    "community": "社区活动"
   },
   "search": {
     "placeholder": "搜索文章、项目...",

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -17,6 +17,8 @@ const router = createRouter({
         { path: 'articles',   name: 'articles',       component: () => import('@/views/public/ArticlesView.vue'),  meta: { title: '文章' } },
         { path: 'articles/:slug', name: 'article-detail', component: () => import('@/views/public/ArticleDetail.vue'), meta: { title: '文章详情' } },
         { path: 'projects',   name: 'projects',       component: () => import('@/views/public/ProjectsView.vue'),  meta: { title: '项目' } },
+        { path: 'playground', name: 'playground',     component: () => import('@/views/public/PlaygroundView.vue'), meta: { title: '代码运行' } },
+        { path: 'community',  name: 'community',     component: () => import('@/views/CommunityActivities.vue'),  meta: { title: '社区活动' } },
       ],
     },
 

--- a/frontend/src/views/public/PlaygroundView.vue
+++ b/frontend/src/views/public/PlaygroundView.vue
@@ -1,0 +1,69 @@
+<template>
+  <div class="playground-page">
+    <div class="pg-hero">
+      <h1 class="pg-title">
+        <span class="pg-title-icon">⚡</span>
+        代码运行器
+      </h1>
+      <p class="pg-desc">在线运行 Python / Node.js / Bash / Go，支持代码分享与 AI 分析</p>
+    </div>
+    <div class="pg-content">
+      <CodePlayground
+        :initial-language="lang"
+        :snippet-id="snippetId"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { useRoute } from 'vue-router'
+import CodePlayground from '@/components/CodePlayground.vue'
+
+const route     = useRoute()
+const lang      = computed(() => route.query.lang || 'python')
+const snippetId = computed(() => route.query.snippet || null)
+</script>
+
+<style scoped>
+.playground-page {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 32px 20px 60px;
+}
+
+.pg-hero {
+  margin-bottom: 24px;
+}
+
+.pg-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 1.75rem;
+  font-weight: 800;
+  margin: 0 0 8px;
+  background: linear-gradient(135deg, #7aadff, #c4a8ff);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.pg-title-icon {
+  -webkit-text-fill-color: initial;
+  font-size: 1.5rem;
+}
+
+.pg-desc {
+  margin: 0;
+  font-size: .9375rem;
+  color: var(--c-text-muted);
+}
+
+.pg-content {
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+}
+</style>


### PR DESCRIPTION
## 变更内容

两个已完成但「孤立」的页面正式接入路由和导航：

### 新增路由
- `/playground` → `PlaygroundView.vue`（包装 `CodePlayground` 组件）
- `/community` → `CommunityActivities.vue`

### 导航栏
- 桌面端 + 移动端均新增 ⚡ 代码运行 / 🎉 社区活动 两个链接

### 新建文件
- `PlaygroundView.vue`：带 hero 标题的包装页，支持 `?lang=` 和 `?snippet=` 查询参数（分享链接直接打开对应语言/片段）

### i18n
- `nav.playground` / `nav.community` 中英文均已补充

### 后端
- `sandbox` / `community` 路由已在 main.py 注册，无需改动
- 无 Docker 时 sandbox 自动降级为 mock 响应