### PR TITLE
feat(auth): full MFA/TOTP integration

### DIFF
--- a/backend/alembic/versions/a1b2c3d4e5f6_add_mfa_fields.py
+++ b/backend/alembic/versions/a1b2c3d4e5f6_add_mfa_fields.py
@@ -1,0 +1,25 @@
+"""add mfa fields to users
+
+Revision ID: a1b2c3d4e5f6
+Revises: bcc714072d0a
+Create Date: 2026-04-13 09:55:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'a1b2c3d4e5f6'
+down_revision = 'bcc714072d0a'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('users', sa.Column('mfa_enabled', sa.Boolean(), nullable=False, server_default='0'))
+    op.add_column('users', sa.Column('mfa_secret', sa.String(64), nullable=True))
+    op.add_column('users', sa.Column('mfa_pending_secret', sa.String(64), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('users', 'mfa_pending_secret')
+    op.drop_column('users', 'mfa_secret')
+    op.drop_column('users', 'mfa_enabled')

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -2,10 +2,27 @@ from fastapi import APIRouter, Depends, HTTPException
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.orm import Session
 
-from app.core.security import create_access_token, decode_token
+from app.core.security import (
+    create_access_token,
+    create_mfa_token,
+    decode_mfa_token,
+    decode_token,
+)
 from app.db.session import get_db
 from app.models.user import User
-from app.schemas.user import LoginRequest, Token, UserOut
+from app.schemas.user import (
+    LoginRequest,
+    MfaChallenge,
+    MfaVerify,
+    Token,
+    UserOut,
+)
+from app.utils.mfa import (
+    generate_totp_secret,
+    get_totp_qr_base64,
+    verify_totp,
+)
+from pydantic import BaseModel
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 _bearer = HTTPBearer(auto_error=False)
@@ -35,14 +52,47 @@ def require_admin(user: User = Depends(get_current_user)) -> User:
     return user
 
 
-# ── 路由 ───────────────────────────────────────────────────
+# ── 登录 ───────────────────────────────────────────────────
 
 
-@router.post("/login", response_model=Token, summary="登录获取 Token")
+@router.post("/login", summary="登录获取 Token（支持 MFA 二步验证）")
 def login(body: LoginRequest, db: Session = Depends(get_db)):
     user = db.query(User).filter(User.username == body.username).first()
-    if not user or not body.password == user.hashed_password:
+    if not user or body.password != user.hashed_password:
         raise HTTPException(401, "用户名或密码错误")
+
+    # 未启用 MFA：直接返回 Token
+    if not user.mfa_enabled:
+        token = create_access_token(user.id)
+        return Token(access_token=token, user=UserOut.model_validate(user))
+
+    # 已启用 MFA，本次请求携带了 mfa_code → 直接完成验证
+    if body.mfa_code:
+        if not verify_totp(user.mfa_secret, body.mfa_code):
+            raise HTTPException(401, "验证码错误或已过期")
+        token = create_access_token(user.id)
+        return Token(access_token=token, user=UserOut.model_validate(user))
+
+    # 已启用 MFA，但没带 code → 返回 MFA challenge（HTTP 202）
+    mfa_token = create_mfa_token(user.id)
+    from fastapi.responses import JSONResponse
+    return JSONResponse(
+        status_code=202,
+        content=MfaChallenge(mfa_required=True, mfa_token=mfa_token).model_dump(),
+    )
+
+
+@router.post("/login/mfa", response_model=Token, summary="MFA 二步验证完成登录")
+def login_mfa(body: MfaVerify, db: Session = Depends(get_db)):
+    """第二步：校验 TOTP 码，返回正式 Token"""
+    user_id = decode_mfa_token(body.mfa_token)
+    if user_id is None:
+        raise HTTPException(401, "MFA token 无效或已过期（5 分钟内有效）")
+    user = db.get(User, user_id)
+    if not user or not user.is_active:
+        raise HTTPException(401, "用户不存在或已禁用")
+    if not verify_totp(user.mfa_secret, body.code):
+        raise HTTPException(401, "验证码错误或已过期")
     token = create_access_token(user.id)
     return Token(access_token=token, user=UserOut.model_validate(user))
 
@@ -50,3 +100,59 @@ def login(body: LoginRequest, db: Session = Depends(get_db)):
 @router.get("/me", response_model=UserOut, summary="获取当前用户信息")
 def me(user: User = Depends(get_current_user)):
     return user
+
+
+# ── MFA 管理接口 ────────────────────────────────────────────
+
+
+class MfaCodeBody(BaseModel):
+    code: str
+
+
+@router.post("/security/mfa/setup", summary="生成 MFA 绑定二维码（第一步）")
+def mfa_setup(user: User = Depends(require_admin), db: Session = Depends(get_db)):
+    """生成新的 TOTP Secret 并返回 QR 码，尚未正式启用（需 confirm 步骤）"""
+    secret = generate_totp_secret()
+    user.mfa_pending_secret = secret
+    db.commit()
+    qr = get_totp_qr_base64(secret, user.username)
+    return {"secret": secret, "qr_code": qr}
+
+
+@router.post("/security/mfa/confirm", summary="验证 TOTP 码并启用 MFA（第二步）")
+def mfa_confirm(
+    body: MfaCodeBody,
+    user: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    if not user.mfa_pending_secret:
+        raise HTTPException(400, "请先调用 /setup 获取二维码")
+    if not verify_totp(user.mfa_pending_secret, body.code):
+        raise HTTPException(400, "验证码错误，请重试")
+    user.mfa_secret          = user.mfa_pending_secret
+    user.mfa_pending_secret  = None
+    user.mfa_enabled         = True
+    db.commit()
+    return {"message": "MFA 已成功启用"}
+
+
+@router.post("/security/mfa/disable", summary="关闭 MFA（需验证当前 TOTP 码）")
+def mfa_disable(
+    body: MfaCodeBody,
+    user: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    if not user.mfa_enabled:
+        raise HTTPException(400, "MFA 未启用")
+    if not verify_totp(user.mfa_secret, body.code):
+        raise HTTPException(400, "验证码错误")
+    user.mfa_enabled        = False
+    user.mfa_secret         = None
+    user.mfa_pending_secret = None
+    db.commit()
+    return {"message": "MFA 已关闭"}
+
+
+@router.get("/security/mfa/status", summary="查询 MFA 启用状态")
+def mfa_status(user: User = Depends(require_admin)):
+    return {"mfa_enabled": user.mfa_enabled}

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -21,6 +21,27 @@ def create_access_token(subject: int, expires_minutes: Optional[int] = None) -> 
     )
 
 
+def create_mfa_token(user_id: int) -> str:
+    """MFA 中间凭证，5 分钟有效，仅用于完成 MFA 验证"""
+    expire = datetime.now(UTC) + timedelta(minutes=5)
+    return jwt.encode(
+        {"sub": str(user_id), "exp": expire, "scope": "mfa"},
+        settings.APP_SECRET_KEY,
+        algorithm=ALGORITHM,
+    )
+
+
+def decode_mfa_token(token: str) -> Optional[int]:
+    """Returns user_id or None. Only accepts tokens with scope=mfa."""
+    try:
+        payload = jwt.decode(token, settings.APP_SECRET_KEY, algorithms=[ALGORITHM])
+        if payload.get("scope") != "mfa":
+            return None
+        return int(payload["sub"])
+    except (JWTError, KeyError, ValueError):
+        return None
+
+
 def decode_token(token: str) -> Optional[int]:
     """Returns user_id (int) or None."""
     try:

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -36,6 +36,11 @@ class User(Base):
     # }
     resume_data = Column(Text)
 
+    # ── MFA ─────────────────────────────────────────────────────
+    mfa_enabled = Column(Boolean, default=False, nullable=False, server_default="0")
+    mfa_secret  = Column(String(64), nullable=True)  # Base32 TOTP secret
+    mfa_pending_secret = Column(String(64), nullable=True)  # 绑定中，尚未确认
+
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
 

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -80,6 +80,18 @@ class PasswordChange(BaseModel):
 class LoginRequest(BaseModel):
     username: str
     password: str
+    mfa_code: Optional[str] = None  # 登录时带上 TOTP 码（已开启 MFA 时必须）
+
+
+class MfaChallenge(BaseModel):
+    """MFA 二步验证中间状态"""
+    mfa_required: bool = True
+    mfa_token: str  # 短期 JWT，仅用于完成 MFA
+
+
+class MfaVerify(BaseModel):
+    mfa_token: str
+    code: str
 
 
 class Token(BaseModel):

--- a/frontend/src/api/endpoints.js
+++ b/frontend/src/api/endpoints.js
@@ -2,7 +2,8 @@ import http from './http.js'
 
 // ── Auth ────────────────────────────────────────────────
 export const authApi = {
-  login: (data) => http.post('/auth/login', data),
+  login:    (data) => http.post('/auth/login', data),
+  loginMfa: (data) => http.post('/auth/login/mfa', data),
   me:    ()     => http.get('/auth/me'),
 }
 

--- a/frontend/src/components/MFASetup.vue
+++ b/frontend/src/components/MFASetup.vue
@@ -62,7 +62,7 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, onMounted } from 'vue'
 import http from '@/api/http.js'
 
 const mfaEnabled = ref(false)
@@ -73,6 +73,15 @@ const code    = ref('')
 const loading = ref(false)
 const message = ref('')
 const msgType = ref('success')
+
+onMounted(async () => {
+  try {
+    const data = await http.get('/auth/security/mfa/status')
+    mfaEnabled.value = data.mfa_enabled
+  } catch {
+    // 非致命错误，保持默认关闭状态
+  }
+})
 
 async function startSetup() {
   loading.value = true

--- a/frontend/src/store/auth.js
+++ b/frontend/src/store/auth.js
@@ -9,13 +9,34 @@ export const useAuthStore = defineStore('auth', () => {
   const isLoggedIn = computed(() => !!token.value)
   const isAdmin    = computed(() => !!user.value?.is_admin)
 
+  /**
+   * login() returns:
+   *   { access_token, user }          → login complete
+   *   { mfa_required: true, mfa_token } → MFA challenge, caller must show TOTP input
+   */
   async function login(username, password) {
     const data = await authApi.login({ username, password })
+
+    // MFA challenge (HTTP 202 → axios resolves normally)
+    if (data?.mfa_required) {
+      return data  // { mfa_required: true, mfa_token }
+    }
+
+    _setSession(data)
+    return data
+  }
+
+  async function loginMfa(mfaToken, code) {
+    const data = await authApi.loginMfa({ mfa_token: mfaToken, code })
+    _setSession(data)
+    return data
+  }
+
+  function _setSession(data) {
     token.value = data.access_token
     user.value  = data.user
     localStorage.setItem('token', data.access_token)
     localStorage.setItem('user',  JSON.stringify(data.user))
-    return data
   }
 
   function logout() {
@@ -25,5 +46,5 @@ export const useAuthStore = defineStore('auth', () => {
     localStorage.removeItem('user')
   }
 
-  return { token, user, isLoggedIn, isAdmin, login, logout }
+  return { token, user, isLoggedIn, isAdmin, login, loginMfa, logout }
 })

--- a/frontend/src/views/admin/LoginView.vue
+++ b/frontend/src/views/admin/LoginView.vue
@@ -5,7 +5,8 @@
       <h1 class="login-title">后台登录</h1>
       <p class="text-muted" style="font-size:.875rem;margin-bottom:28px">Personal Portfolio CMS</p>
 
-      <el-form :model="form" @submit.prevent="submit">
+      <!-- Step 1: 用户名 + 密码 -->
+      <el-form v-if="step === 'password'" :model="form" @submit.prevent="submit">
         <el-form-item>
           <el-input
             v-model="form.username"
@@ -38,15 +39,44 @@
         </el-button>
       </el-form>
 
-      <p style="margin-top:20px;font-size:.8125rem;color:#64748b">
-        <router-link to="/" style="color:#64748b">← 返回主页</router-link>
-      </p>
+      <!-- Step 2: MFA TOTP 验证码 -->
+      <div v-else-if="step === 'mfa'" class="mfa-step">
+        <div class="mfa-hint">
+          <span class="mfa-icon-sm">🔐</span>
+          请输入 Authenticator App 中的 6 位验证码
+        </div>
+        <input
+          ref="codeInputRef"
+          v-model="mfaCode"
+          class="code-input"
+          placeholder="000000"
+          maxlength="6"
+          inputmode="numeric"
+          autocomplete="one-time-code"
+          @keyup.enter="submitMfa"
+        />
+        <el-button
+          type="primary"
+          size="large"
+          :loading="loading"
+          :disabled="mfaCode.length < 6"
+          style="width:100%;margin-top:12px"
+          @click="submitMfa"
+        >
+          {{ loading ? '验证中...' : '验 证' }}
+        </el-button>
+        <p class="back-link" @click="backToPassword">← 使用其他账号登录</p>
+      </div>
     </div>
+
+    <p style="margin-top:20px;font-size:.8125rem;color:#64748b">
+      <router-link to="/" style="color:#64748b">← 返回主页</router-link>
+    </p>
   </div>
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, nextTick } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { ElMessage } from 'element-plus'
 import { useAuthStore } from '@/store/auth.js'
@@ -55,8 +85,12 @@ const router = useRouter()
 const route  = useRoute()
 const auth   = useAuthStore()
 
-const loading = ref(false)
-const form    = ref({ username: '', password: '' })
+const loading      = ref(false)
+const form         = ref({ username: '', password: '' })
+const step         = ref('password')   // 'password' | 'mfa'
+const mfaCode      = ref('')
+const mfaToken     = ref('')
+const codeInputRef = ref(null)
 
 async function submit() {
   if (!form.value.username || !form.value.password) {
@@ -65,7 +99,18 @@ async function submit() {
   }
   loading.value = true
   try {
-    await auth.login(form.value.username, form.value.password)
+    const data = await auth.login(form.value.username, form.value.password)
+
+    if (data?.mfa_required) {
+      // 进入 MFA 第二步
+      mfaToken.value = data.mfa_token
+      step.value     = 'mfa'
+      mfaCode.value  = ''
+      await nextTick()
+      codeInputRef.value?.focus()
+      return
+    }
+
     ElMessage.success('登录成功')
     const redirect = route.query.redirect || '/admin/dashboard'
     router.push(decodeURIComponent(redirect))
@@ -75,11 +120,35 @@ async function submit() {
     loading.value = false
   }
 }
+
+async function submitMfa() {
+  if (mfaCode.value.length < 6) return
+  loading.value = true
+  try {
+    await auth.loginMfa(mfaToken.value, mfaCode.value)
+    ElMessage.success('登录成功')
+    const redirect = route.query.redirect || '/admin/dashboard'
+    router.push(decodeURIComponent(redirect))
+  } catch (e) {
+    ElMessage.error(e?.detail || '验证码错误或已过期')
+    mfaCode.value = ''
+    codeInputRef.value?.focus()
+  } finally {
+    loading.value = false
+  }
+}
+
+function backToPassword() {
+  step.value    = 'password'
+  mfaCode.value = ''
+  mfaToken.value = ''
+}
 </script>
 
 <style scoped>
 .login-page {
-  min-height: 100vh; display: flex; align-items: center; justify-content: center;
+  min-height: 100vh; display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
   background: radial-gradient(ellipse at center, rgba(59,130,246,.12) 0%, transparent 70%);
 }
 .login-box {
@@ -89,4 +158,22 @@ async function submit() {
 .login-icon  { font-size: 2.75rem; margin-bottom: 12px; }
 .login-title { font-size: 1.625rem; font-weight: 800; color: #f1f5f9; margin-bottom: 6px; }
 .el-form-item { margin-bottom: 14px; }
+
+/* MFA step */
+.mfa-step   { display: flex; flex-direction: column; align-items: center; gap: 14px; }
+.mfa-hint   { display: flex; align-items: center; gap: 8px; color: #94a3b8; font-size: .9rem; text-align: left; }
+.mfa-icon-sm { font-size: 1.25rem; }
+.code-input {
+  width: 180px; text-align: center; letter-spacing: .5em;
+  font-size: 1.75rem; font-family: monospace; font-weight: 700;
+  padding: 12px 8px; border-radius: 10px;
+  border: 2px solid #334155; background: #0f172a;
+  color: #f1f5f9; outline: none;
+  transition: border-color .15s;
+}
+.code-input:focus { border-color: #3b82f6; }
+.back-link {
+  font-size: .8125rem; color: #64748b; cursor: pointer; margin-top: 4px;
+}
+.back-link:hover { color: #94a3b8; }
 </style>

--- a/frontend/src/views/admin/ProfileEditor.vue
+++ b/frontend/src/views/admin/ProfileEditor.vue
@@ -76,6 +76,12 @@
         💾 保存
       </el-button>
     </el-form>
+
+    <!-- 账号安全 -->
+    <div style="max-width:900px;margin-top:40px">
+      <h2 class="page-h2">🔐 账号安全</h2>
+      <MFASetup />
+    </div>
   </div>
 </template>
 
@@ -83,6 +89,7 @@
 import { ref, onMounted } from 'vue'
 import { ElMessage } from 'element-plus'
 import { profileApi } from '@/api/endpoints.js'
+import MFASetup from '@/components/MFASetup.vue'
 
 const loading = ref(false)
 const saving  = ref(false)


### PR DESCRIPTION
MFA 双因子认证完整接入。

后端：User 模型加 mfa 字段、Alembic 迁移、security.py 增 mfa token、auth.py 完整 MFA 路由（setup/confirm/disable/status/login二步）。

前端：LoginView 两步流、auth store 支持 mfa_required、MFASetup 初始化状态、ProfileEditor 嵌入安全设置。

部署后需 alembic upgrade head。