### PR TITLE
feat(admin): add Playground link to admin sidebar

### DIFF
--- a/frontend/src/layouts/AdminLayout.vue
+++ b/frontend/src/layouts/AdminLayout.vue
@@ -68,7 +68,7 @@ import { ref, computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { ElMessage } from 'element-plus'
 import {
-  DataAnalysis, User, Document, Monitor,
+  DataAnalysis, User, Document, Monitor, Operation,
   House, SwitchButton, Close, Menu,
 } from '@element-plus/icons-vue'
 import { useAuthStore } from '@/store/auth.js'
@@ -84,6 +84,7 @@ const navItems = [
   { to: '/admin/profile',   label: '个人资料', icon: 'User' },
   { to: '/admin/articles',  label: '文章管理', icon: 'Document' },
   { to: '/admin/projects',  label: '项目管理', icon: 'Monitor' },
+  { to: '/playground',      label: '代码运行', icon: 'Operation' },
 ]
 
 const currentNav = computed(() =>


### PR DESCRIPTION
## Admin 侧边栏增加 Playground 入口

### 改动
- 从  引入  图标
-  新增一项：「代码运行」→ 

### 效果
管理员登录后台时，侧边栏会显示：
- 📊 概览
- 👤 个人资料
- 📄 文章管理
- 🖥️ 项目管理
- ⚙️ **代码运行**（新增）

点击后跳转到代码沙箱页面，无需手动输入 URL。

### 用户体验提升
- **之前**：管理员需要记住  URL 或从公开导航栏进入
- **现在**：后台侧边栏直达，操作更顺畅